### PR TITLE
chore(ci): use Node 24 Pages configuration action

### DIFF
--- a/.github/workflows/viewer-pages.yml
+++ b/.github/workflows/viewer-pages.yml
@@ -60,7 +60,7 @@ jobs:
           package-manager-cache: false
       - name: Configure GitHub Pages
         id: pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Verify viewer dependencies and application logic
         run: |
           test "$(node --version)" = "v$NODE_VERSION"


### PR DESCRIPTION
## Summary\n- update the immutable configure-pages pin from v5.0.0 to v6.0.0\n- remove the Node 20 deprecation annotation from the Pages build\n\n## Validation\n- python scripts/check_workflow_policy.py\n- python -m unittest scripts.test_workflow_policy\n- git diff --check