### PR TITLE
fix(release): support public multi-commit history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,6 @@ jobs:
             echo "release identity requires complete Git history" >&2
             exit 1
           }
-          test "$(git rev-list --count HEAD)" = "1" || {
-            echo "release source must contain exactly one public commit" >&2
-            exit 1
-          }
           test "$(git rev-list --max-parents=0 --count HEAD)" = "1" || {
             echo "release source must contain exactly one parentless root" >&2
             exit 1

--- a/scripts/check_workflow_policy.py
+++ b/scripts/check_workflow_policy.py
@@ -2022,10 +2022,7 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
             "must not cancel an in-flight external publication"
         ),
         'test "$(git rev-parse --is-shallow-repository)" = "false"': (
-            "must reject shallow history before enforcing the one-root release"
-        ),
-        'test "$(git rev-list --count HEAD)" = "1"': (
-            "must require the release source to contain exactly one commit"
+            "must reject shallow history before enforcing the single-root release"
         ),
         'test "$(git rev-list --max-parents=0 --count HEAD)" = "1"': (
             "must require exactly one parentless public root"
@@ -2158,11 +2155,23 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
         )
     if "git merge-base --is-ancestor" in identity_step:
         errors.append(f"{path}: ancestor-only release tag validation is forbidden")
-    one_commit = 'test "$(git rev-list --count HEAD)" = "1"'
     one_root = 'test "$(git rev-list --max-parents=0 --count HEAD)" = "1"'
-    if identity_step.count(one_commit) != 1 or identity_step.count(one_root) != 1:
+    if identity_step.count(one_root) != 1:
         errors.append(
-            f"{path}: release identity step must enforce one complete parentless commit"
+            f"{path}: release identity step must enforce one complete parentless root"
+        )
+    total_commit_probes = [
+        line
+        for line in identity_step.splitlines()
+        if "git rev-list" in line
+        and "--count" in line
+        and "HEAD" in line
+        and "--max-parents=0" not in line
+    ]
+    if total_commit_probes:
+        errors.append(
+            f"{path}: release identity must not restrict the public history to a "
+            "fixed total commit count"
         )
     shallow_check = 'test "$(git rev-parse --is-shallow-repository)" = "false"'
     if identity_step.count(shallow_check) != 1:

--- a/scripts/test_workflow_policy.py
+++ b/scripts/test_workflow_policy.py
@@ -500,9 +500,10 @@ steps:
                 "true",
                 1,
             ),
-            "release_commit_count": original.replace(
-                'test "$(git rev-list --count HEAD)" = "1"',
-                'test "$(git rev-list --count HEAD)" -ge "1"',
+            "release_total_commit_restriction": original.replace(
+                '          test "$(git rev-list --max-parents=0 --count HEAD)" = "1" || {\n',
+                '          test "$(git rev-list --count HEAD)" = "1"\n'
+                '          test "$(git rev-list --max-parents=0 --count HEAD)" = "1" || {\n',
                 1,
             ),
             "release_root_count": original.replace(


### PR DESCRIPTION
Closes #62\n\n## Summary\n- remove the obsolete requirement that release source contain exactly one total commit\n- retain full-history checkout, exactly one parentless root, exact public main equality, and hosted tag revalidation\n- reject reintroduction of fixed total-commit probes through workflow-policy mutation tests\n\n## Validation\n- python scripts/check_workflow_policy.py\n- python -m unittest scripts.test_workflow_policy (49 tests, 1 skipped)\n- python scripts/public_hygiene_audit.py\n- git diff --check