### PR TITLE
feat(mcp): add bounded workbook comparison

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -260,7 +260,7 @@ cargo build --release --manifest-path bindings/mcp/Cargo.toml --locked
 bindings/mcp/target/release/rxls-mcp --root /path/to/spreadsheets
 ```
 
-8개 도구, 클라이언트 설정, 파일시스템 경계, 자원 제한은
+9개 도구, 클라이언트 설정, 파일시스템 경계, 자원 제한은
 [MCP 서버 가이드(English)](bindings/mcp/README.md)에 정리되어 있습니다.
 
 현재 게시된 코어 릴리스는 `0.1.3`입니다. 렌더러,

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ cargo build --release --manifest-path bindings/mcp/Cargo.toml --locked
 bindings/mcp/target/release/rxls-mcp --root /path/to/spreadsheets
 ```
 
-See the [MCP server guide](bindings/mcp/README.md) for its eight tools, client
+See the [MCP server guide](bindings/mcp/README.md) for its nine tools, client
 configuration, filesystem boundary, and resource limits.
 
 Version `0.1.3` is the current published core release. The renderer,

--- a/bindings/mcp/README.md
+++ b/bindings/mcp/README.md
@@ -41,6 +41,7 @@ With no `--root`, the current directory is the only allowed root.
 | `workbook_list_sessions` | List active sessions and retained byte totals |
 | `workbook_inspect` | Inspect format, sheets, provenance, and edit capability |
 | `workbook_read_range` | Read up to 10,000 cells as typed structured output |
+| `workbook_compare` | Compare typed and displayed values across up to 10,000 cells |
 | `workbook_export_sheet` | Export bounded CSV, Markdown, or HTML |
 | `workbook_set_cells` | Atomically set values or write formulas to up to 100 cells |
 | `workbook_save_copy` | Publish a new same-format XLSX/XLSM copy without overwrite |
@@ -51,6 +52,9 @@ With no `--root`, the current directory is the only allowed root.
 - Existing paths and allowed roots are canonicalized before comparison.
 - Workbook inputs are capped at 32 MiB; four sessions may retain 128 MiB total.
 - One JSON-RPC line and one structured tool result are each capped at 1 MiB.
+- Range comparisons inspect at most 10,000 cells and return at most 100 detailed
+  differences within a 512 KiB detail budget, plus complete count and explicit
+  count/size truncation status.
 - Workbook data is accepted by local path only, never as base64 in MCP JSON.
 - XLS, XLSB, and ODS sessions are read-only. XLSX/XLSM edits require rxls's
   lossless retained-package capability.

--- a/bindings/mcp/src/a1.rs
+++ b/bindings/mcp/src/a1.rs
@@ -36,7 +36,7 @@ impl CellRange {
         let cols = usize::from(end.col - start.col + 1);
         if rows.saturating_mul(cols) > MAX_RANGE_CELLS {
             return Err(format!(
-                "RXLS_MCP_RANGE_TOO_LARGE: at most {MAX_RANGE_CELLS} cells may be read"
+                "RXLS_MCP_RANGE_TOO_LARGE: at most {MAX_RANGE_CELLS} cells may be processed"
             ));
         }
         Ok(Self { start, end })

--- a/bindings/mcp/src/lib.rs
+++ b/bindings/mcp/src/lib.rs
@@ -24,6 +24,10 @@ pub const MAX_SESSION_BYTES: usize = 128 * 1024 * 1024;
 pub const MAX_SESSIONS: usize = 4;
 /// Maximum cells returned by one range read.
 pub const MAX_RANGE_CELLS: usize = 10_000;
+/// Maximum cell differences returned by one comparison.
+pub const MAX_COMPARE_DIFFERENCES: usize = 100;
+/// Maximum serialized bytes reserved for comparison difference details.
+pub const MAX_COMPARE_DETAIL_BYTES: usize = MAX_OUTPUT_BYTES / 2;
 /// Maximum cell edits accepted by one atomic MCP call.
 pub const MAX_BATCH_EDITS: usize = 100;
 /// Maximum serialized payload returned by one tool call.

--- a/bindings/mcp/src/model.rs
+++ b/bindings/mcp/src/model.rs
@@ -26,6 +26,20 @@ pub(crate) struct ReadRangeParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub(crate) struct CompareWorkbooksParams {
+    /// Opaque ID for the left workbook returned by `workbook_open`.
+    pub(crate) left_session_id: String,
+    /// Case-sensitive worksheet name in the left workbook.
+    pub(crate) left_sheet: String,
+    /// Opaque ID for the right workbook returned by `workbook_open`.
+    pub(crate) right_session_id: String,
+    /// Case-sensitive worksheet name in the right workbook.
+    pub(crate) right_sheet: String,
+    /// Inclusive A1 range compared at matching coordinates, for example `A1:D20`.
+    pub(crate) range: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct ExportSheetParams {
     /// Opaque ID returned by `workbook_open`.
     pub(crate) session_id: String,
@@ -173,7 +187,7 @@ pub(crate) struct InspectWorkbookResult {
     pub(crate) provenance: ParseProvenanceResult,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum TypedCell {
     Text {
@@ -213,6 +227,43 @@ pub(crate) struct ReadRangeResult {
     pub(crate) range: String,
     pub(crate) cell_count: usize,
     pub(crate) rows: Vec<Vec<CellResult>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+pub(crate) struct ComparedCell {
+    pub(crate) value: Option<TypedCell>,
+    pub(crate) display: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub(crate) struct CellDifference {
+    pub(crate) address: String,
+    pub(crate) row: u32,
+    pub(crate) column: u16,
+    pub(crate) left: ComparedCell,
+    pub(crate) right: ComparedCell,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub(crate) struct CompareWorkbooksResult {
+    pub(crate) left_session_id: String,
+    pub(crate) left_sha256: String,
+    pub(crate) left_sheet: String,
+    pub(crate) right_session_id: String,
+    pub(crate) right_sha256: String,
+    pub(crate) right_sheet: String,
+    pub(crate) range: String,
+    pub(crate) compared_cells: usize,
+    pub(crate) identical: bool,
+    pub(crate) difference_count: usize,
+    pub(crate) returned_differences: usize,
+    pub(crate) max_returned_differences: usize,
+    pub(crate) returned_detail_bytes: usize,
+    pub(crate) max_detail_bytes: usize,
+    pub(crate) differences_truncated: bool,
+    pub(crate) truncated_by_count: bool,
+    pub(crate) truncated_by_size: bool,
+    pub(crate) differences: Vec<CellDifference>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/bindings/mcp/src/server.rs
+++ b/bindings/mcp/src/server.rs
@@ -19,13 +19,15 @@ use sha2::{Digest, Sha256};
 
 use crate::a1::{format_cell, parse_cell, CellAddress, CellRange};
 use crate::model::{
-    CellEdit, CellResult, CloseSessionResult, ExportFormat, ExportSheetParams, ExportSheetResult,
+    CellDifference, CellEdit, CellResult, CloseSessionResult, CompareWorkbooksParams,
+    CompareWorkbooksResult, ComparedCell, ExportFormat, ExportSheetParams, ExportSheetResult,
     InputValue, InspectWorkbookResult, ListSessionsResult, OpenWorkbookParams, OpenWorkbookResult,
     ParseProvenanceResult, ReadRangeParams, ReadRangeResult, SaveCopyParams, SaveCopyResult,
     SessionParams, SessionSummary, SetCellsParams, SetCellsResult, SheetSummary, TypedCell,
 };
 use crate::{
-    MAX_BATCH_EDITS, MAX_OUTPUT_BYTES, MAX_SESSIONS, MAX_SESSION_BYTES, MAX_WORKBOOK_BYTES,
+    MAX_BATCH_EDITS, MAX_COMPARE_DETAIL_BYTES, MAX_COMPARE_DIFFERENCES, MAX_OUTPUT_BYTES,
+    MAX_SESSIONS, MAX_SESSION_BYTES, MAX_WORKBOOK_BYTES,
 };
 
 static SAVE_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -438,6 +440,91 @@ impl RxlsMcpServer {
         })
     }
 
+    /// Compare a bounded A1 range across two open workbook sessions.
+    #[tool(
+        description = "Compare typed and displayed values for at most 10,000 matching worksheet cells",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    fn workbook_compare(
+        &self,
+        Parameters(params): Parameters<CompareWorkbooksParams>,
+    ) -> Result<Json<CompareWorkbooksResult>, String> {
+        let range = CellRange::parse(&params.range)?;
+        let state = self.state()?;
+        let left_session = find_session(&state, &params.left_session_id)?;
+        let right_session = find_session(&state, &params.right_session_id)?;
+        let left_sheet = find_worksheet(left_session.spreadsheet.workbook(), &params.left_sheet)?;
+        let right_sheet =
+            find_worksheet(right_session.spreadsheet.workbook(), &params.right_sheet)?;
+
+        let mut difference_count = 0usize;
+        let mut returned_detail_bytes = 0usize;
+        let mut truncated_by_count = false;
+        let mut truncated_by_size = false;
+        let mut differences = Vec::new();
+        for row in range.start.row..=range.end.row {
+            for col in range.start.col..=range.end.col {
+                if left_sheet.cell(row, col) == right_sheet.cell(row, col)
+                    && left_sheet.formatted(row, col) == right_sheet.formatted(row, col)
+                {
+                    continue;
+                }
+                difference_count = difference_count.saturating_add(1);
+                if differences.len() >= MAX_COMPARE_DIFFERENCES {
+                    truncated_by_count = true;
+                    continue;
+                }
+                let difference = CellDifference {
+                    address: format_cell(CellAddress { row, col }),
+                    row: row + 1,
+                    column: col + 1,
+                    left: compared_cell(left_sheet, row, col),
+                    right: compared_cell(right_sheet, row, col),
+                };
+                let detail_bytes = serde_json::to_vec(&difference)
+                    .map_err(|_| {
+                        error(
+                            "RXLS_MCP_SERIALIZE_FAILED",
+                            "comparison detail could not be serialized",
+                        )
+                    })?
+                    .len();
+                if returned_detail_bytes.saturating_add(detail_bytes) > MAX_COMPARE_DETAIL_BYTES {
+                    truncated_by_size = true;
+                    continue;
+                }
+                returned_detail_bytes += detail_bytes;
+                differences.push(difference);
+            }
+        }
+        let returned_differences = differences.len();
+        checked_json(CompareWorkbooksResult {
+            left_session_id: left_session.id.clone(),
+            left_sha256: left_session.current_sha256.clone(),
+            left_sheet: left_sheet.name.clone(),
+            right_session_id: right_session.id.clone(),
+            right_sha256: right_session.current_sha256.clone(),
+            right_sheet: right_sheet.name.clone(),
+            range: params.range,
+            compared_cells: range.cell_count(),
+            identical: difference_count == 0,
+            difference_count,
+            returned_differences,
+            max_returned_differences: MAX_COMPARE_DIFFERENCES,
+            returned_detail_bytes,
+            max_detail_bytes: MAX_COMPARE_DETAIL_BYTES,
+            differences_truncated: returned_differences < difference_count,
+            truncated_by_count,
+            truncated_by_size,
+            differences,
+        })
+    }
+
     /// Export one worksheet as bounded deterministic text.
     #[tool(
         description = "Export one worksheet as bounded CSV, Markdown, or HTML",
@@ -647,7 +734,7 @@ impl RxlsMcpServer {
 }
 
 #[tool_handler(
-    instructions = "Open a workbook first. Use the returned session_id for bounded reads, exports, preservation-aware XLSX/XLSM edits, save-copy, and close. All paths remain below server-configured roots."
+    instructions = "Open a workbook first. Use returned session IDs for bounded reads, comparisons, exports, preservation-aware XLSX/XLSM edits, save-copy, and close. All paths remain below server-configured roots."
 )]
 impl ServerHandler for RxlsMcpServer {}
 
@@ -830,6 +917,13 @@ fn typed_cell(cell: &Cell) -> TypedCell {
             formula: formula.clone(),
             cached: Box::new(typed_cell(cached)),
         },
+    }
+}
+
+fn compared_cell(sheet: &Sheet, row: u32, col: u16) -> ComparedCell {
+    ComparedCell {
+        value: sheet.cell(row, col).map(typed_cell),
+        display: sheet.formatted(row, col).map(str::to_string),
     }
 }
 
@@ -1059,6 +1153,39 @@ mod tests {
         fs::write(path, bytes).expect("write sample workbook");
     }
 
+    fn write_number_column_xlsx(path: &Path, offset: f64, cells: usize) {
+        let mut workbook = rxls::Workbook::new();
+        let sheet = workbook.add_sheet("Data");
+        for row in 0..cells {
+            sheet.write_number(
+                u32::try_from(row).expect("test row fits in u32"),
+                0,
+                row as f64 + offset,
+            );
+        }
+        let bytes = workbook
+            .to_xlsx_checked()
+            .expect("author comparison workbook");
+        fs::write(path, bytes).expect("write comparison workbook");
+    }
+
+    fn write_text_column_xlsx(path: &Path, prefix: &str, cells: usize) {
+        let mut workbook = rxls::Workbook::new();
+        let sheet = workbook.add_sheet("Data");
+        let suffix = "x".repeat(20_000);
+        for row in 0..cells {
+            sheet.write_string(
+                u32::try_from(row).expect("test row fits in u32"),
+                0,
+                format!("{prefix}-{row:04}-{suffix}"),
+            );
+        }
+        let bytes = workbook
+            .to_xlsx_checked()
+            .expect("author long-text workbook");
+        fs::write(path, bytes).expect("write long-text workbook");
+    }
+
     fn server_for(root: &TempDir) -> RxlsMcpServer {
         RxlsMcpServer::new(
             ServerConfig::new(vec![root.path().to_path_buf()]).expect("configure server root"),
@@ -1209,8 +1336,96 @@ mod tests {
             .starts_with("RXLS_MCP_EDIT_LIMIT:"));
     }
 
+    #[test]
+    fn compares_bounded_ranges_and_reports_truncation() {
+        let root = TempDir::new().unwrap();
+        let left_path = root.path().join("left.xlsx");
+        let right_path = root.path().join("right.xlsx");
+        write_number_column_xlsx(&left_path, 0.0, 101);
+        write_number_column_xlsx(&right_path, 1.0, 101);
+        let server = server_for(&root);
+        let left = open_sample(&server, &left_path);
+        let right = open_sample(&server, &right_path);
+
+        let compared = server
+            .workbook_compare(Parameters(CompareWorkbooksParams {
+                left_session_id: left.session.session_id.clone(),
+                left_sheet: "Data".to_string(),
+                right_session_id: right.session.session_id,
+                right_sheet: "Data".to_string(),
+                range: "A1:A101".to_string(),
+            }))
+            .expect("compare workbooks")
+            .0;
+        assert!(!compared.identical);
+        assert_eq!(compared.compared_cells, 101);
+        assert_eq!(compared.difference_count, 101);
+        assert_eq!(compared.returned_differences, MAX_COMPARE_DIFFERENCES);
+        assert_eq!(compared.max_returned_differences, MAX_COMPARE_DIFFERENCES);
+        assert!(compared.returned_detail_bytes <= compared.max_detail_bytes);
+        assert!(compared.differences_truncated);
+        assert!(compared.truncated_by_count);
+        assert!(!compared.truncated_by_size);
+        assert_eq!(compared.differences.first().unwrap().address, "A1");
+        assert_eq!(compared.differences.last().unwrap().address, "A100");
+        assert!(matches!(
+            compared.differences[0].left.value,
+            Some(TypedCell::Number { value: 0.0 })
+        ));
+        assert!(matches!(
+            compared.differences[0].right.value,
+            Some(TypedCell::Number { value: 1.0 })
+        ));
+
+        let identical = server
+            .workbook_compare(Parameters(CompareWorkbooksParams {
+                left_session_id: left.session.session_id.clone(),
+                left_sheet: "Data".to_string(),
+                right_session_id: left.session.session_id,
+                right_sheet: "Data".to_string(),
+                range: "A1:A101".to_string(),
+            }))
+            .expect("compare identical session")
+            .0;
+        assert!(identical.identical);
+        assert_eq!(identical.difference_count, 0);
+        assert!(identical.differences.is_empty());
+        assert!(!identical.differences_truncated);
+        assert!(!identical.truncated_by_count);
+        assert!(!identical.truncated_by_size);
+    }
+
+    #[test]
+    fn comparison_detail_bytes_remain_bounded_for_long_cells() {
+        let root = TempDir::new().unwrap();
+        let left_path = root.path().join("long-left.xlsx");
+        let right_path = root.path().join("long-right.xlsx");
+        write_text_column_xlsx(&left_path, "left", 20);
+        write_text_column_xlsx(&right_path, "right", 20);
+        let server = server_for(&root);
+        let left = open_sample(&server, &left_path);
+        let right = open_sample(&server, &right_path);
+
+        let compared = server
+            .workbook_compare(Parameters(CompareWorkbooksParams {
+                left_session_id: left.session.session_id,
+                left_sheet: "Data".to_string(),
+                right_session_id: right.session.session_id,
+                right_sheet: "Data".to_string(),
+                range: "A1:A20".to_string(),
+            }))
+            .expect("compare long cells")
+            .0;
+        assert_eq!(compared.difference_count, 20);
+        assert!(compared.returned_differences < compared.difference_count);
+        assert!(compared.returned_detail_bytes <= MAX_COMPARE_DETAIL_BYTES);
+        assert!(compared.differences_truncated);
+        assert!(!compared.truncated_by_count);
+        assert!(compared.truncated_by_size);
+    }
+
     #[tokio::test]
-    async fn exposes_eight_tools_and_structured_results_over_mcp() {
+    async fn exposes_nine_tools_and_structured_results_over_mcp() {
         let root = TempDir::new().unwrap();
         let source = root.path().join("protocol.xlsx");
         write_sample_xlsx(&source);
@@ -1237,6 +1452,7 @@ mod tests {
             names,
             BTreeSet::from([
                 "workbook_close",
+                "workbook_compare",
                 "workbook_export_sheet",
                 "workbook_inspect",
                 "workbook_list_sessions",
@@ -1253,6 +1469,7 @@ mod tests {
                 .is_some_and(|annotations| annotations.open_world_hint == Some(false))
         }));
         for name in [
+            "workbook_compare",
             "workbook_export_sheet",
             "workbook_inspect",
             "workbook_list_sessions",
@@ -1287,6 +1504,35 @@ mod tests {
                 .and_then(|value| value.get("format"))
                 .and_then(serde_json::Value::as_str),
             Some("xlsx")
+        );
+        let session_id = result
+            .structured_content
+            .as_ref()
+            .and_then(|value| value.get("session_id"))
+            .and_then(serde_json::Value::as_str)
+            .expect("open result session ID");
+        let arguments = json!({
+            "left_session_id": session_id,
+            "left_sheet": "Data",
+            "right_session_id": session_id,
+            "right_sheet": "Data",
+            "range": "A1:B2"
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let compared = client
+            .call_tool(CallToolRequestParams::new("workbook_compare").with_arguments(arguments))
+            .await
+            .expect("call workbook_compare");
+        assert_ne!(compared.is_error, Some(true));
+        assert_eq!(
+            compared
+                .structured_content
+                .as_ref()
+                .and_then(|value| value.get("identical"))
+                .and_then(serde_json::Value::as_bool),
+            Some(true)
         );
 
         client.cancel().await.expect("cancel client");


### PR DESCRIPTION
## Summary
- add a read-only `workbook_compare` MCP tool for matching A1 ranges across two open sessions
- compare both typed values and formatted display text while scanning at most 10,000 cells
- cap returned details at 100 differences and 512 KiB, with complete counts and explicit count/size truncation metadata
- expose and exercise the ninth tool through a real MCP client protocol test

## Validation
- `cargo test --manifest-path bindings/mcp/Cargo.toml --locked` (10 passed)
- `cargo clippy --manifest-path bindings/mcp/Cargo.toml --all-targets --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path bindings/mcp/Cargo.toml --no-deps --locked`
- `cargo package --manifest-path bindings/mcp/Cargo.toml --locked --allow-dirty`
- `cargo-deny --manifest-path bindings/mcp/Cargo.toml --locked --all-features check --config deny.toml`
- `python -m unittest scripts.test_workflow_policy scripts.test_render_supply_chain scripts.test_release_tools` (103 passed, 1 skipped)
- `python scripts/public_hygiene_audit.py`

Closes #50