### PR TITLE
docs(vscode): link the verified public release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,9 @@ updates:
     groups:
       vscode-extension-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # @types/vscode is the compile-time API contract for engines.vscode.
+      # Keep accepting 1.96.x patches while the extension supports VS Code
+      # 1.96; a newer minor requires an explicit minimum-engine migration.
+      - dependency-name: "@types/vscode"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]

--- a/README.ko.md
+++ b/README.ko.md
@@ -191,6 +191,10 @@ VBA를 포함한 손대지 않은 패키지 파트는 그대로 보존합니다.
 extension host와 webview worker 밖으로 나가지 않으며 telemetry나 외부 네트워크
 클라이언트가 없습니다.
 
+[rxls Spreadsheet Preview 0.1.0](https://github.com/HyunjoJung/rxls/releases/tag/vscode-v0.1.0)을
+검증된 VSIX로 내려받을 수 있습니다. 릴리스에는 대응하는 SHA-256 파일과 정확한
+소스 커밋, 크로스 플랫폼 CI 검증 근거가 함께 연결되어 있습니다.
+
 ### 시연 영상
 
 | 한국어 시연 | 영어 시연 |

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ zoom, reload-on-change, and SVG/PNG export. Workbook bytes stay inside the
 extension host and its webview worker; the extension has no telemetry or
 external network client.
 
+[Download rxls Spreadsheet Preview 0.1.0](https://github.com/HyunjoJung/rxls/releases/tag/vscode-v0.1.0)
+as a verified VSIX. The release includes the matching SHA-256 file and links
+the package to its exact source commit and cross-platform CI evidence.
+
 ### Video demos
 
 | English demo | Korean demo |

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -18,9 +18,11 @@ and export the current view as SVG or PNG.
 
 ## Install a VSIX
 
-Download the `.vsix` and matching `.sha256` artifact from a verified release or
-workflow run. In VS Code, choose **Extensions: Install from VSIX...** and select
-the package.
+Download the `.vsix` and matching `.sha256` file from the verified
+[0.1.0 release](https://github.com/HyunjoJung/rxls/releases/tag/vscode-v0.1.0).
+The expected VSIX SHA-256 is
+`3d1307502220c65d2755d7c1ef214a8117127b475fdae0c6da514f6ab3eecfd8`.
+In VS Code, choose **Extensions: Install from VSIX...** and select the package.
 
 ## Security and privacy
 


### PR DESCRIPTION
## Summary

- link the permanent `vscode-v0.1.0` GitHub Release from both public READMEs and the extension README
- publish the verified VSIX SHA-256 next to the installation instructions
- keep `@types/vscode` aligned with the declared VS Code 1.96 API floor until an explicit engine migration

## Validation

- `python -m unittest scripts.test_public_docs scripts.test_workflow_policy`
- `python scripts/public_hygiene_audit.py`
- `cargo package --locked --allow-dirty`
- core package gate: 178 files, 911,560-byte archive, 4,869,459 bytes unpacked
- clean public-release VSIX install on VS Code 1.135.0

The tagged VSIX remains byte-identical to the main CI artifact:
`3d1307502220c65d2755d7c1ef214a8117127b475fdae0c6da514f6ab3eecfd8`.