### PR TITLE
docs(vscode): link public extension registries

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -191,9 +191,14 @@ VBA를 포함한 손대지 않은 패키지 파트는 그대로 보존합니다.
 extension host와 webview worker 밖으로 나가지 않으며 telemetry나 외부 네트워크
 클라이언트가 없습니다.
 
-[rxls Spreadsheet Preview 0.1.0](https://github.com/HyunjoJung/rxls/releases/tag/vscode-v0.1.0)을
-검증된 VSIX로 내려받을 수 있습니다. 릴리스에는 대응하는 SHA-256 파일과 정확한
-소스 커밋, 크로스 플랫폼 CI 검증 근거가 함께 연결되어 있습니다.
+VS Code에서는
+[Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=HyunjoJung.rxls-spreadsheet-preview),
+VSCodium 같은 호환 클라이언트에서는
+[Open VSX Registry](https://open-vsx.org/extension/HyunjoJung/rxls-spreadsheet-preview)에서
+rxls Spreadsheet Preview 0.1.0을 설치할 수 있습니다.
+[GitHub 릴리스](https://github.com/HyunjoJung/rxls/releases/tag/vscode-v0.1.0)는
+바이트 단위 검증을 위한 기준 배포본입니다. 검증된 VSIX와 대응하는 SHA-256 파일,
+정확한 소스 커밋, 크로스 플랫폼 CI 근거를 함께 제공합니다.
 
 ### 시연 영상
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,14 @@ zoom, reload-on-change, and SVG/PNG export. Workbook bytes stay inside the
 extension host and its webview worker; the extension has no telemetry or
 external network client.
 
-[Download rxls Spreadsheet Preview 0.1.0](https://github.com/HyunjoJung/rxls/releases/tag/vscode-v0.1.0)
-as a verified VSIX. The release includes the matching SHA-256 file and links
-the package to its exact source commit and cross-platform CI evidence.
+Install rxls Spreadsheet Preview 0.1.0 from the
+[Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=HyunjoJung.rxls-spreadsheet-preview)
+for VS Code or the
+[Open VSX Registry](https://open-vsx.org/extension/HyunjoJung/rxls-spreadsheet-preview)
+for compatible clients such as VSCodium. The
+[GitHub release](https://github.com/HyunjoJung/rxls/releases/tag/vscode-v0.1.0)
+remains the canonical byte-level artifact: it includes the verified VSIX,
+matching SHA-256 file, exact source commit, and cross-platform CI evidence.
 
 ### Video demos
 

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -16,13 +16,25 @@ and export the current view as SVG or PNG.
 | XLSB | Yes | No |
 | ODS | Yes | No |
 
-## Install a VSIX
+## Install
 
-Download the `.vsix` and matching `.sha256` file from the verified
-[0.1.0 release](https://github.com/HyunjoJung/rxls/releases/tag/vscode-v0.1.0).
-The expected VSIX SHA-256 is
+| Channel | Recommended use |
+|---|---|
+| [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=HyunjoJung.rxls-spreadsheet-preview) | Install directly in VS Code |
+| [Open VSX Registry](https://open-vsx.org/extension/HyunjoJung/rxls-spreadsheet-preview) | Install in VSCodium and other Open VSX clients |
+| [GitHub release](https://github.com/HyunjoJung/rxls/releases/tag/vscode-v0.1.0) | Audit or install the canonical VSIX offline |
+
+The extension identifier is `HyunjoJung.rxls-spreadsheet-preview`. From a
+terminal with VS Code on `PATH`:
+
+```console
+code --install-extension HyunjoJung.rxls-spreadsheet-preview
+```
+
+The verified 0.1.0 VSIX in the GitHub release has SHA-256
 `3d1307502220c65d2755d7c1ef214a8117127b475fdae0c6da514f6ab3eecfd8`.
-In VS Code, choose **Extensions: Install from VSIX...** and select the package.
+For a manual install, download the `.vsix` and matching `.sha256`, then choose
+**Extensions: Install from VSIX...** in VS Code.
 
 ## Security and privacy
 


### PR DESCRIPTION
## Summary
- link the public Visual Studio Marketplace and Open VSX listings
- keep the GitHub Release as the canonical byte-level VSIX and checksum source
- document registry and offline installation paths in the VS Code extension guide

## Verification
- Microsoft Marketplace public listing resolves for HyunjoJung.rxls-spreadsheet-preview 0.1.0
- Marketplace VSIX: 1,512,775 bytes, SHA-256 3d1307502220c65d2755d7c1ef214a8117127b475fdae0c6da514f6ab3eecfd8
- isolated Marketplace install: hyunjojung.rxls-spreadsheet-preview@0.1.0
- python -m unittest discover -s scripts -p test_*.py: 814 OK, 27 skipped
- python scripts/public_hygiene_audit.py
- git diff --check