### PR TITLE
docs: make first contributions easier to start

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,24 +10,32 @@ assignees: ''
 
 A clear, concise description of the problem.
 
+For vulnerabilities, use the private reporting channel in
+[SECURITY.md](https://github.com/HyunjoJung/rxls/blob/main/.github/SECURITY.md).
+
 ## Reproduction
 
-1. A minimal `.xls`, `.xlsx`, `.xlsm`, `.xlsb`, or `.ods` file that triggers it
-   (remove confidential data before attaching)
-2. The exact API or CLI command and enabled Cargo features
+1. A minimal `.xls`, `.xlsx`, `.xlsm`, `.xlsb`, or `.ods` file, a script that
+   generates it, or steps to reproduce it. Share only redistributable,
+   non-confidential content; hidden sheets, properties, comments, and macros
+   can also contain private data. A synthetic example is welcome.
+2. The exact API or CLI command and enabled Cargo features, or viewer/extension
+   steps for a UI problem
 3. The error, panic, wrong value, or changed/dropped package part
 
 ## Expected vs actual
 
-- **Expected:** what the result should be and the independent reader used to verify it
+- **Expected:** what the result should be; include an independent reader
+  comparison if available (not required)
 - **Actual:** what `rxls` produced
 
 ## Environment
 
 - `rxls` version:
-- Rust version (`rustc --version`):
+- Rust version (`rustc --version`, if applicable):
 - Enabled features:
 - OS:
+- Browser or VS Code version (if applicable):
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: First contribution guide
+    url: https://github.com/HyunjoJung/rxls/blob/main/CONTRIBUTING.md
+    about: Find setup instructions, code locations, and focused checks.
+  - name: Report a security vulnerability privately
+    url: https://github.com/HyunjoJung/rxls/security/advisories/new
+    about: Use private reporting for exploitable crashes, resource exhaustion, or other vulnerabilities.

--- a/.github/ISSUE_TEMPLATE/contribution_question.md
+++ b/.github/ISSUE_TEMPLATE/contribution_question.md
@@ -1,0 +1,26 @@
+---
+name: Contribution question
+about: Ask for a starting point or help with a contribution
+title: ''
+labels: question
+assignees: ''
+---
+
+## What I would like to work on
+
+Link an existing issue or describe the area that interests you. Documentation,
+examples, reproductions, and tests are welcome as well as code changes.
+
+## Where I need a pointer
+
+Describe what would help: a relevant file, expected behavior, setup, a test
+command, or feedback on a small proposed change.
+
+## What I have tried
+
+Optional: include commands and errors, or link a draft PR. Remove private
+workbook content and credentials from logs.
+
+The [contribution guide](https://github.com/HyunjoJung/rxls/blob/main/CONTRIBUTING.md)
+has setup and focused validation instructions. Vulnerabilities belong in the
+[private security reporting channel](https://github.com/HyunjoJung/rxls/security/advisories/new).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,8 +17,9 @@ The use case, and ideally a minimal public workbook that exercises it.
 
 ## References
 
-Relevant MS-XLS, MS-XLSB, MS-CFB, ECMA-376, or ODF sections, and how an
-independent implementation handles it.
+Relevant MS-XLS, MS-XLSB, MS-CFB, ECMA-376, or ODF sections, or how another
+implementation handles it, if known. Specification research is not required
+to describe a user need.
 
 ## Alternatives
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,16 +4,20 @@ Briefly describe the problem this PR solves and what changed.
 
 ## Related issue
 
-Closes #
+Link an issue if there is one. Small corrections do not require an issue.
 
 ## Verification
 
-- The full local gate in `CONTRIBUTING.md` passes
-- New behavior and malformed-input boundaries are covered by tests
-- Reader, XML, ZIP, or dependency changes ran the relevant public-corpus gate
-- Input-controlled work and allocation remain bounded
-- Format changes cite the relevant public specification section
-- Public API or release-visible changes update docs and the changelog
+List the exact commands you ran and their results. Use the focused checks in
+`CONTRIBUTING.md`; mention checks you could not run and why. For documentation,
+describe any links or examples you verified. A draft PR can request help with
+a specific failing test or incomplete implementation.
+
+For behavior changes, explain the regression test and any affected format,
+preservation, or resource-limit boundary. Cite specification sections where
+the format behavior depends on them. Note relevant documentation or changelog
+updates. Maintainers select additional corpus, fuzz, or installed-product
+checks as needed before merge.
 
 ## Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,119 @@ library that reads `.xls` (BIFF8/5/7), `.xlsx`, `.xlsb`, and `.ods`, writes
 and package-preservingly edits `.xlsx`/`.xlsm`, evaluates a deterministic
 formula subset, and exports CSV/HTML/Markdown.
 
+## Your first contribution
+
+Start with a [good first issue] or browse [help wanted]. Each task describes
+the relevant files, expected result, and a focused check. Documentation,
+usage examples, small reproductions, and tests are welcome contributions;
+you do not need to understand every spreadsheet format to help.
+
+1. Read the issue and its comments, then leave a short comment if you plan to
+   work on it so others can coordinate. Ask for pointers when the scope is
+   unclear. Small documentation corrections can go straight to a PR.
+2. Fork the repository and create a branch from `main`. Keep the change about
+   one problem. For a bug fix, add a small regression test that fails before
+   the fix and passes afterward.
+3. Open a PR against `main` with the problem, the change, and the exact checks
+   you ran. A draft PR with a reproduction or a specific question is useful
+   even when the fix is unfinished.
+
+Run the checks for your changed area below before opening a PR. You do not
+need to reproduce the full release matrix to request review. State any check
+you could not run and why; passing the applicable CI and additional
+maintainer-run gates is still required before merge or publication.
+
+If none of the listed tasks fits, open a [contribution question] with the area
+you want to work on. For larger features, discuss the user need and scope in
+an issue before implementation. Please follow the [Code of Conduct].
+
+## Set up only what you need
+
+For core Rust changes, install [Rust through rustup], then run from the
+repository root:
+
+```sh
+rustup toolchain install 1.85.0 --profile minimal --component rustfmt --component clippy
+cargo +1.85.0 test --lib --all-features --locked
+```
+
+This uses the committed lockfile and does not need Excel, Java, LibreOffice,
+Node.js, or an external workbook corpus. The first build downloads Rust
+dependencies. On macOS, put rustup's proxies before any Homebrew Rust tools
+with `export PATH="$HOME/.cargo/bin:$PATH"`.
+
+For documentation-only edits, start with your editor and `git diff --check`.
+Check links and run any example you change. Python repository checks require
+Python 3.11 or newer.
+
+For viewer or VS Code work, use Node.js 24.18.0 with npm 11.16.0, matching the
+hosted tooling. Install only the package you are changing with
+`npm ci --prefix viewer --ignore-scripts` or
+`npm ci --prefix extensions/vscode --ignore-scripts`.
+
+The core and renderer support Rust 1.85. For the separate MCP adapter, install
+its Rust 1.88 toolchain and use `cargo +1.88.0` for that package:
+
+```sh
+rustup toolchain install 1.88.0 --profile minimal --component rustfmt --component clippy
+```
+
+Browser and installed-extension tests have extra prerequisites documented in
+their package guides.
+
+## Choose a focused check
+
+All commands below run from the repository root. For Rust changes, also run
+`cargo +1.85.0 fmt --all -- --check` (or the changed package's `cargo fmt`).
+
+| Changed area | Start here | More context |
+| --- | --- | --- |
+| Prose and links | `git diff --check`; check links and any changed example | [README](README.md), [public docs](docs/compatibility.md) |
+| Core readers, writer, editor, or formulas | `cargo +1.85.0 test --lib --all-features --locked` | `src/`, [format internals](docs/format-internals.md) |
+| CLI | `cargo +1.85.0 test --test cli --all-features --locked` | `src/main.rs`, `tests/cli.rs` |
+| Public API or fixture regressions | `cargo +1.85.0 test --test integration --test api_contract --all-features --locked` | `tests/`, [fixture provenance](tests/fixtures/README.md) |
+| Renderer | `cargo +1.85.0 test --manifest-path render/Cargo.toml --all-targets --locked` | [Renderer guide](render/README.md) |
+| Viewer application logic | `npm --prefix viewer test` | [Viewer setup and browser tests](viewer/README.md) |
+| Render worker JavaScript | `npm --prefix bindings/render-wasm test` | [Worker setup and WASM tests](bindings/render-wasm/README.md) |
+| MCP adapter | `cargo +1.88.0 test --manifest-path bindings/mcp/Cargo.toml --locked` | [MCP guide](bindings/mcp/README.md) |
+| VS Code extension | `npm --prefix extensions/vscode test` | [Extension setup and E2E tests](extensions/vscode/README.md) |
+
+You can append a test-name filter to a Cargo test command while iterating.
+Check that the output reports the intended test ran; a result with zero tests
+does not verify the change. Run the containing suite before requesting review.
+User-visible browser or extension changes also need their package's browser
+or E2E journey; unit tests alone do not check the rendered interface.
+
+Changes to readers, XML/ZIP handling, dependencies, or resource limits may
+need corpus, fuzz, or rendering-oracle checks. Describe the affected formats
+in the PR so maintainers can select the appropriate hosted runs. Contributors
+do not need registry credentials or access to maintainer release environments.
+
+## Reproductions and workbook fixtures
+
+A small generated workbook or a test built from in-memory bytes is often the
+best reproduction. Include the command or API call, enabled features, and
+expected versus actual result. An independent reader comparison helps when
+available, but is not required to report an ordinary bug.
+
+For contributed files, record the source, license, producing application when
+known, and expected values. Follow the [fixture guide](tests/fixtures/README.md)
+for committed generated fixtures and their manifest. Include only files you
+may redistribute. Remove confidential data, including hidden sheets,
+properties, comments, and macros, before sharing a workbook; recreating the
+problem with synthetic data is preferable.
+
+Report exploitable crashes, unbounded resource use, and other vulnerabilities
+through the [private security reporting channel], following the
+[Security Policy](.github/SECURITY.md).
+
 ## Ground rules
 
 - **No `unsafe`.** The crate is `#![forbid(unsafe_code)]`. Parsing untrusted
   files must never crash a host process — every byte access is bounds-checked
   and malformed input must never panic. Recovery must be bounded and preserve
-  source meaning; otherwise the input must surface as an [`Error`].
+  source meaning; otherwise the input must surface as an
+  [`Error`](https://docs.rs/rxls/latest/rxls/enum.Error.html).
 - **Document every public item.** The crate denies `missing_docs`.
 - **Keep dependencies minimal.** The default build depends only on `cfb`,
   `encoding_rs`, `thiserror`, `zip`, and `quick-xml` (the latter two behind
@@ -24,12 +131,18 @@ formula subset, and exports CSV/HTML/Markdown.
   read and write/edit paths, and edits must be preflighted so a failed edit
   never leaves a half-mutated package.
 
-## Before opening a PR
+## Full integration and release validation
+
+Maintainers and contributors working across multiple surfaces use the full
+matrix below before integration or release, together with the applicable
+hosted checks. It is a reference for broader validation, not a prerequisite
+for opening a focused or draft PR.
 
 Install the pinned registry-compatibility checker with
 `cargo install cargo-semver-checks --version 0.49.0 --locked`, ensure the
-`wasm32-unknown-unknown` Rust target is installed, then run the full local gate
-(all must pass clean):
+`wasm32-unknown-unknown` Rust target is installed, and install the oracle
+dependencies described in [Validation and reproducibility](docs/validation.md).
+Run the full local gate; all applicable checks must pass clean:
 
 On macOS, put rustup's cargo proxy before any Homebrew Rust installation so
 `cargo +1.85.0`, `cargo +nightly`, and the API checker use the pinned toolchain:
@@ -133,3 +246,9 @@ than interpreted. Larger features are welcome — open an issue first.
 [MS-XLS]: https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-xls/
 [MS-XLSB]: https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-xlsb/
 [MS-CFB]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/
+[good first issue]: https://github.com/HyunjoJung/rxls/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22
+[help wanted]: https://github.com/HyunjoJung/rxls/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22
+[contribution question]: https://github.com/HyunjoJung/rxls/issues/new?template=contribution_question.md
+[Code of Conduct]: .github/CODE_OF_CONDUCT.md
+[Rust through rustup]: https://rustup.rs/
+[private security reporting channel]: https://github.com/HyunjoJung/rxls/security/advisories/new

--- a/README.ko.md
+++ b/README.ko.md
@@ -24,6 +24,9 @@ panic 대신 처리 범위가 제한된 타입 오류로 반환합니다.
 cargo add rxls@0.1.3 --features full
 ```
 
+기여하고 싶다면 [첫 기여용 이슈](https://github.com/HyunjoJung/rxls/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)와
+[시작 가이드(English)](CONTRIBUTING.md#your-first-contribution)를 확인해 보세요.
+
 ## rxls를 쓰는 이유
 
 - **하나의 읽기 모델.** `Workbook::open` 한 번으로 XLS, XLSX, XLSB, ODS를
@@ -286,8 +289,12 @@ bindings/mcp/target/release/rxls-mcp --root /path/to/spreadsheets
 
 ## 기여
 
-이슈와 pull request를 환영합니다. [CONTRIBUTING.md](CONTRIBUTING.md)는 로컬
-검증 절차, 공개 API 요구사항, 입력 범위 제한 정책, 사양 인용 규칙을 설명합니다.
+코드 변경뿐 아니라 예제, 문서, 재현 가능한 버그 보고, 회귀 테스트도 환영합니다.
+[첫 기여용 이슈](https://github.com/HyunjoJung/rxls/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)나
+[도움이 필요한 작업](https://github.com/HyunjoJung/rxls/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22)에서
+시작해 보세요. [기여 가이드(English)](CONTRIBUTING.md#your-first-contribution)는
+환경 설정, 관련 코드 위치, 변경 범위별 검증 명령을 안내합니다. 질문과 draft PR도
+환영하며, 리뷰를 요청하기 위해 전체 릴리스 검증을 먼저 실행할 필요는 없습니다.
 [Code of Conduct](.github/CODE_OF_CONDUCT.md)와
 [Security Policy](.github/SECURITY.md)도 함께 적용됩니다.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ bounded inputs and typed failures for malformed or unsupported documents.
 cargo add rxls@0.1.3 --features full
 ```
 
+Want to help? Start with a [good first issue](https://github.com/HyunjoJung/rxls/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
+and the [first-contribution guide](CONTRIBUTING.md#your-first-contribution).
+
 ## Why rxls
 
 - **One read model.** `Workbook::open` detects XLS, XLSX, XLSB, or ODS and
@@ -285,9 +288,13 @@ gated workspace surfaces and are not part of the published core crate contract.
 
 ## Contributing
 
-Issues and pull requests are welcome. [CONTRIBUTING.md](CONTRIBUTING.md)
-documents the local gate, public API requirements, bounded-input policy, and
-specification citation rules. See also the
+Examples, documentation, reproducible bug reports, and regression tests are
+welcome alongside code changes. Pick a [good first issue](https://github.com/HyunjoJung/rxls/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
+or browse [help wanted](https://github.com/HyunjoJung/rxls/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22).
+The [contribution guide](CONTRIBUTING.md#your-first-contribution) explains setup,
+where the code lives, and which focused checks to run for your change. Draft
+PRs and questions are welcome; the full release matrix is not required to
+request review. See also the
 [Code of Conduct](.github/CODE_OF_CONDUCT.md) and
 [Security Policy](.github/SECURITY.md).
 


### PR DESCRIPTION
## Summary

New contributors previously encountered the full release validation matrix before opening a PR, and the PR template assumed it had all passed. The guide now starts with a small contribution flow, setup by package, and focused checks; broader integration and publication gates remain required.

Both READMEs link to starter issues. Issue templates accept minimal reproductions and contribution questions, while the PR template asks for actual commands and results.

## Related issues

Adds entry points for the independently scoped contributor tasks #79, #80, #81, #82, #83, and #84. Those tasks remain open for contributors.

## Verification

- Public hygiene audit and `git diff --check` passed.
- Validated all issue-template YAML and 59 local Markdown links/anchors.
- Ran the documented core starting command: 888 library tests passed on Rust 1.85.
- Confirmed focused commands run real tests: Serde 1, CSV 3, MCP edit/save 1.
- Viewer core/ZIP tests: 12 passed.

## Notes

Documentation and templates only. No runtime code, dependency, or hosted gate changes.

