### PR TITLE
fix(viewer): reject empty numeric and date cell inputs

### DIFF
--- a/viewer/src/core.js
+++ b/viewer/src/core.js
@@ -189,6 +189,14 @@ function editableScalar(kind, value) {
       return { kind, value: String(value ?? "") };
     case "number":
     case "date": {
+      if (
+        (typeof value !== "number" && typeof value !== "string") ||
+        (typeof value === "string" && value.trim() === "")
+      ) {
+        throw new TypeError(
+          kind === "date" ? "Enter a finite Excel date serial." : "Enter a finite number."
+        );
+      }
       const number = Number(value);
       if (!Number.isFinite(number)) {
         throw new TypeError(

--- a/viewer/tests/core.test.mjs
+++ b/viewer/tests/core.test.mjs
@@ -54,6 +54,10 @@ test("parses bounded A1 references", () => {
 test("builds strict typed cell edits", () => {
   assert.deepEqual(editableCell("blank"), { kind: "blank" });
   assert.deepEqual(editableCell("number", "42.5"), { kind: "number", value: 42.5 });
+  assert.deepEqual(editableCell("number", "0"), { kind: "number", value: 0 });
+  assert.deepEqual(editableCell("number", 0), { kind: "number", value: 0 });
+  assert.deepEqual(editableCell("date", "0"), { kind: "date", value: 0 });
+  assert.deepEqual(editableCell("date", 45000), { kind: "date", value: 45000 });
   assert.deepEqual(editableCell("boolean", "false"), { kind: "boolean", value: false });
   assert.deepEqual(
     editableCell("formula", "=SUM(A1:A2)", {
@@ -66,9 +70,59 @@ test("builds strict typed cell edits", () => {
       cached: { kind: "number", value: 3 }
     }
   );
+  assert.deepEqual(
+    editableCell("formula", "=A1", {
+      cachedKind: "number",
+      cachedValue: "0"
+    }),
+    {
+      kind: "formula",
+      formula: "A1",
+      cached: { kind: "number", value: 0 }
+    }
+  );
   assert.throws(() => editableCell("number", "not-a-number"), TypeError);
   assert.throws(() => editableCell("formula", "="), TypeError);
   assert.throws(() => editableCell("formula", "A1", { cachedKind: "blank" }), TypeError);
+});
+
+test("rejects empty and whitespace-only numeric and date cell inputs", () => {
+  assert.throws(() => editableCell("number", ""), TypeError);
+  assert.throws(() => editableCell("number", "   "), TypeError);
+  assert.throws(() => editableCell("date", ""), TypeError);
+  assert.throws(() => editableCell("date", "   "), TypeError);
+  assert.throws(
+    () =>
+      editableCell("formula", "=A1", {
+        cachedKind: "number",
+        cachedValue: ""
+      }),
+    TypeError
+  );
+  assert.throws(
+    () =>
+      editableCell("formula", "=A1", {
+        cachedKind: "number",
+        cachedValue: "   "
+      }),
+    TypeError
+  );
+  assert.throws(
+    () =>
+      editableCell("formula", "=A1", {
+        cachedKind: "date",
+        cachedValue: ""
+      }),
+    TypeError
+  );
+  assert.throws(
+    () =>
+      editableCell("formula", "=A1", {
+        cachedKind: "date",
+        cachedValue: "   "
+      }),
+    TypeError
+  );
 });
 
 test("preserves macro-enabled save-as extensions and describes read-only reasons", () => {


### PR DESCRIPTION
## Summary

Fixes #82.

Rejects empty and whitespace-only strings for numeric and date cell inputs (as well as numeric/date formula-cache inputs) before numeric conversion in `editableScalar`.

### Problem
Previously, leaving Number or Date values empty or whitespace-only in the browser cell editor passed `Number(value)` which coerced `""` and `"   "` to `0`, incorrectly setting the cell value to `0`.

### Changes
- In `viewer/src/core.js` (`editableScalar`): Validate that `value` is either a number or a non-empty, non-whitespace string before `Number(value)`. Throws a `TypeError` (`"Enter a finite number."` / `"Enter a finite Excel date serial."`) for empty or whitespace-only inputs.
- Preserved behavior for explicit zero (`"0"`, `0`), supported finite numbers, and `blank` cells.
- When `editableCell` throws, `submitCellEdit` catches the error and surfaces the validation message via `describeError` / `showError`, preventing empty inputs from being submitted to the worker.
- Added regression tests in `viewer/tests/core.test.mjs` verifying:
  - Empty string `""` and whitespace `"   "` are rejected for both `number` and `date`.
  - Empty and whitespace formula-cache values for `number` and `date` are rejected.
  - Explicit `"0"`, `0`, and date serials remain valid.

### Validation
Ran focused test suite:
```
$ node --test viewer/tests/core.test.mjs
✔ accepts the documented workbook extensions case-insensitively
✔ formats metadata deterministically
✔ creates path-neutral export names
✔ parses bounded A1 references
✔ builds strict typed cell edits
✔ rejects empty and whitespace-only numeric and date cell inputs
✔ preserves macro-enabled save-as extensions and describes read-only reasons
✔ accepts only the latest delayed request
✔ matches loaded cells by client, document, sheet, and coordinate
✔ clamps explicit and fitted zoom
✔ maps stable worker failures to user-facing messages
ℹ tests 11
ℹ pass 11
```

Reproduction verification:
```
$ node --input-type=module -e 'import { editableCell } from "./viewer/src/core.js"; console.log(editableCell("number", ""));'
TypeError: Enter a finite number.

$ node --input-type=module -e 'import { editableCell } from "./viewer/src/core.js"; console.log(editableCell("date", "   "));'
TypeError: Enter a finite Excel date serial.

$ node --input-type=module -e 'import { editableCell } from "./viewer/src/core.js"; console.log(editableCell("number", "0")); console.log(editableCell("blank"));'
{ kind: 'number', value: 0 }
{ kind: 'blank' }
```