### PR TITLE
Preserve editing continuity and isolate release publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,13 @@ jobs:
             --output target/rxls-sbom.cdx.json
           git diff --exit-code -- Cargo.lock bindings/wasm/Cargo.lock bindings/mcp/Cargo.lock
       - name: Package dry run
+        shell: bash
         run: |
+          set -euo pipefail
+          python3 scripts/check_release_identity.py
+          version=$(python3 -c "import pathlib,tomllib; print(tomllib.loads(pathlib.Path('Cargo.toml').read_text(encoding='utf-8'))['package']['version'])")
           cargo package --locked
-          python3 scripts/check_core_package.py target/package/rxls-0.1.3.crate
+          python3 scripts/check_core_package.py "target/package/rxls-${version}.crate"
 
   msrv:
     name: MSRV 1.85
@@ -245,11 +249,23 @@ jobs:
           CARGO_BIN_EXE_rxls: target/debug/${{ matrix.executable }}
         run: cargo test --test cli --locked
       - name: Package crate
+        id: package
+        shell: bash
         run: |
+          set -euo pipefail
+          python3 scripts/check_release_identity.py
+          version=$(python3 -c "import pathlib,tomllib; print(tomllib.loads(pathlib.Path('Cargo.toml').read_text(encoding='utf-8'))['package']['version'])")
           cargo package --locked
-          python3 scripts/check_core_package.py target/package/rxls-0.1.3.crate
+          python3 scripts/check_core_package.py "target/package/rxls-${version}.crate"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Install CLI from the exact packaged crate contents
-        run: cargo install --path target/package/rxls-0.1.3 --locked --root target/installed-product
+        shell: bash
+        env:
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          set -euo pipefail
+          version="$PACKAGE_VERSION"
+          cargo install --path "target/package/rxls-${version}" --locked --root target/installed-product
       - name: Smoke installed CLI
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 concurrency:
   group: core-release-${{ github.ref }}
@@ -33,9 +33,17 @@ env:
   NPM_VERSION: "11.16.0"
 
 jobs:
-  publish:
-    name: Verify and publish
+  verify:
+    name: Verify release candidate
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      source_attempt: ${{ steps.release.outputs.source_attempt }}
+      artifact_id: ${{ steps.publication_bundle.outputs.artifact-id }}
+      artifact_digest: ${{ steps.publication_bundle.outputs.artifact-digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -73,6 +81,7 @@ jobs:
             echo "workflow_dispatch is verification-only; no publish will run"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "source_attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (2026-07-15)
         with:
           toolchain: ${{ env.RELEASE_RUST_VERSION }}
@@ -163,7 +172,8 @@ jobs:
             | tee target/wasm-browser-smoke.json
           python3 -m unittest discover -s scripts -p "test_*.py"
           cargo package --locked
-          python3 scripts/check_core_package.py target/package/rxls-0.1.3.crate
+          version="${{ steps.release.outputs.version }}"
+          python3 scripts/check_core_package.py "target/package/rxls-${version}.crate"
           python3 scripts/check_cargo_publish_dry_run.py run \
             --manifest Cargo.toml \
             --git-sha "$GITHUB_SHA" \
@@ -353,8 +363,9 @@ jobs:
 
       - name: Smoke exact packaged crate distribution
         run: |
+          version="${{ steps.release.outputs.version }}"
           python3 scripts/smoke_crate_distribution.py \
-            --crate target/package/rxls-0.1.3.crate \
+            --crate "target/package/rxls-${version}.crate" \
             --write-report target/release-crate-distribution-smoke.json
 
       - name: Generate release evidence
@@ -841,7 +852,7 @@ jobs:
             ! -name rxls-release-manifest.json \
             ! -name public-hygiene.json -print | LC_ALL=C sort)
           [[ ${#artifacts[@]} -eq 50 ]] || {
-            echo "publication manifest input count differs from the 0.1.3 contract" >&2
+            echo "publication manifest input count differs from the reviewed contract" >&2
             exit 1
           }
           python3 scripts/release_manifest.py \
@@ -856,12 +867,156 @@ jobs:
             --version "$version" \
             --git-rev "$GITHUB_SHA"
 
+      - name: Upload verified publication bundle
+        id: publication_bundle
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rxls-${{ steps.release.outputs.version }}-publication-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 30
+
+  publish:
+    name: Publish verified release
+    needs: verify
+    if: github.repository == 'HyunjoJung/rxls' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: crates-io
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate publication identity
+        id: release
+        env:
+          VERIFIED_VERSION: ${{ needs.verify.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "HyunjoJung/rxls"
+          test "$GITHUB_EVENT_NAME" = "push"
+          test "$GITHUB_REF" = "refs/tags/v$VERIFIED_VERSION"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          version=$(python3 -c "import pathlib,tomllib; print(tomllib.loads(pathlib.Path('Cargo.toml').read_text(encoding='utf-8'))['package']['version'])")
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]
+          test "$version" = "$VERIFIED_VERSION"
+          git fetch origin main --no-tags
+          test "$(git rev-parse origin/main)" = "$GITHUB_SHA"
+          git fetch origin "refs/tags/$GITHUB_REF_NAME" --no-tags
+          test "$(git rev-parse 'FETCH_HEAD^{commit}')" = "$GITHUB_SHA"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (2026-07-15)
+        with:
+          toolchain: ${{ env.RELEASE_RUST_VERSION }}
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-cache: false
+      - name: Authenticate verified publication artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ needs.verify.outputs.artifact_id }}
+          ARTIFACT_DIGEST: ${{ needs.verify.outputs.artifact_digest }}
+          SOURCE_ATTEMPT: ${{ needs.verify.outputs.source_attempt }}
+          VERIFIED_VERSION: ${{ needs.verify.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]
+          mkdir -p target/publication
+          gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID" \
+            > target/publication/artifact.json
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          artifact = json.loads(Path("target/publication/artifact.json").read_text())
+          expected_digest = os.environ["ARTIFACT_DIGEST"].removeprefix("sha256:")
+          attempt = os.environ["SOURCE_ATTEMPT"]
+          if not re.fullmatch(r"[0-9a-f]{64}", expected_digest):
+              raise SystemExit("invalid verified artifact digest")
+          if not re.fullmatch(r"[1-9][0-9]*", attempt) or int(attempt) > int(os.environ["GITHUB_RUN_ATTEMPT"]):
+              raise SystemExit("invalid verified source attempt")
+          expected_name = (
+              f"rxls-{os.environ['VERIFIED_VERSION']}-publication-"
+              f"{os.environ['GITHUB_SHA']}-{os.environ['GITHUB_RUN_ID']}-{attempt}"
+          )
+          if not isinstance(artifact, dict):
+              raise SystemExit("invalid publication artifact metadata")
+          expected = {
+              "id": int(os.environ["ARTIFACT_ID"]),
+              "name": expected_name,
+              "digest": f"sha256:{expected_digest}",
+              "expired": False,
+          }
+          if any(type(artifact.get(key)) is not type(value) or artifact[key] != value for key, value in expected.items()):
+              raise SystemExit("publication artifact identity differs from verified output")
+          run = artifact.get("workflow_run")
+          expected_run = {
+              "id": int(os.environ["GITHUB_RUN_ID"]),
+              "head_sha": os.environ["GITHUB_SHA"],
+              "repository_id": int(os.environ["GITHUB_REPOSITORY_ID"]),
+              "head_repository_id": int(os.environ["GITHUB_REPOSITORY_ID"]),
+          }
+          if not isinstance(run, dict) or any(type(run.get(key)) is not type(value) or run[key] != value for key, value in expected_run.items()):
+              raise SystemExit("publication artifact source differs from this verified run")
+          PY
+      - name: Download exact verified publication bundle
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          artifact-ids: ${{ needs.verify.outputs.artifact_id }}
+          path: dist
+          merge-multiple: true
+          digest-mismatch: error
+      - name: Verify publication handoff and package bytes
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.release.outputs.version }}"
+          python3 scripts/check_workflow_policy.py
+          python3 scripts/check_release_identity.py
+          python3 scripts/check_cargo_publish_dry_run.py verify \
+            --manifest Cargo.toml \
+            --git-sha "$GITHUB_SHA" \
+            --receipt dist/release-cargo-publish-dry-run.json
+          python3 scripts/release_manifest.py \
+            --verify-bundle dist \
+            --expected-files 52 \
+            --version "$version" \
+            --git-rev "$GITHUB_SHA"
+          python3 scripts/check_core_package.py "dist/rxls-${version}.crate"
+          # Cargo has no stable publish-existing-archive command. Repacking the
+          # exact clean source must reproduce the verified archive byte for byte.
+          cargo package --locked
+          cmp "target/package/rxls-${version}.crate" "dist/rxls-${version}.crate"
+      - name: Install published WASM browser smoke runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(node --version)" = "v$NODE_VERSION"
+          test "$(npm --version)" = "$NPM_VERSION"
+          npm install --prefix target/playwright --no-save --ignore-scripts playwright@1.54.1
+          npm exec --prefix target/playwright -- playwright install --with-deps chromium
+
       - name: Publish to crates.io
         if: github.event_name == 'push'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
+          set -euo pipefail
           git fetch origin main --no-tags
           test "$(git rev-parse origin/main)" = "$GITHUB_SHA"
           git fetch origin "refs/tags/$GITHUB_REF_NAME" --no-tags
@@ -915,10 +1070,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          version="${{ steps.release.outputs.version }}"
           passed=false
           for attempt in $(seq 1 12); do
             if python3 scripts/smoke_crate_distribution.py \
-              --registry-version 0.1.3 \
+              --registry-version "$version" \
               --write-report target/release-crates-io-distribution-smoke.json; then
               passed=true
               break
@@ -931,7 +1087,7 @@ jobs:
         if: always() && github.event_name == 'push'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: rxls-0.1.3-crates-io-smoke-${{ github.run_attempt }}
+          name: rxls-${{ steps.release.outputs.version }}-crates-io-smoke-${{ github.run_attempt }}
           path: target/release-crates-io-distribution-smoke.json
           if-no-files-found: warn
           retention-days: 30
@@ -1054,5 +1210,5 @@ jobs:
           JS
             node "$GITHUB_WORKSPACE/bindings/wasm/tests/browser-smoke.mjs" \
               "$smoke/wasm-consumer/node_modules/rxls-wasm" \
-              "$GITHUB_WORKSPACE/target/wasm-native-report.json"
+              "$smoke/assets/wasm-native-report.json"
           )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   package against the canonical core release archive.
 - Expanded MCP protocol and VS Code installed, restricted, and virtual-workspace
   regression coverage.
+- Separated read-only core release verification from protected publication,
+  binding the publishing job to the exact verified artifact and package bytes.
+
+### Fixed
+
+- Kept cached-formula warnings through document-property edits and aligned
+  their restoration with undo/redo without carrying them into another workbook.
+- Preserved the current print-preview page when applying edits or undo/redo,
+  clamping only when refreshed pagination requires it.
+- Allowed Tab and Shift+Tab to leave the worksheet at its cell boundaries,
+  while retaining a failed edit's draft and keyboard focus for correction.
+- Released pending document-property controls even when the workbook changes
+  before a request finishes.
 
 ## [0.1.3] - 2026-08-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,9 @@ python3 scripts/libreoffice-render-parity.py --corpus tests/fixtures \
   --dry-run --max-files 8 \
   --report target/libreoffice-render-parity-dry-run.json
 cargo package --locked
-python3 scripts/check_core_package.py target/package/rxls-0.1.3.crate
+python3 scripts/check_release_identity.py
+version=$(python3 -c "import pathlib,tomllib; print(tomllib.loads(pathlib.Path('Cargo.toml').read_text(encoding='utf-8'))['package']['version'])")
+python3 scripts/check_core_package.py "target/package/rxls-${version}.crate"
 cargo publish --dry-run --locked
 ```
 

--- a/scripts/check_workflow_policy.py
+++ b/scripts/check_workflow_policy.py
@@ -1974,11 +1974,102 @@ def audit_release_versions(path: Path, text: str) -> list[str]:
     return audit_fuzz_tools(path, text, tuple(RELEASE_VERSIONS))
 
 
+def audit_ci_package_versions(path: Path, text: str) -> list[str]:
+    """Package and install the validated manifest version on every CI platform."""
+
+    errors: list[str] = []
+    active = _without_commented_lines(text)
+    version_read = (
+        'version=$(python3 -c "import pathlib,tomllib; '
+        "print(tomllib.loads(pathlib.Path('Cargo.toml').read_text(encoding='utf-8'))"
+        "['package']['version'])\")"
+    )
+    package_check = 'python3 scripts/check_core_package.py "target/package/rxls-${version}.crate"'
+    for header in ("- name: Package dry run", "- name: Package crate"):
+        step = _single_yaml_block(path, active, header, 6, header, errors)
+        required = (
+            "shell: bash", "set -euo pipefail",
+            "python3 scripts/check_release_identity.py", version_read,
+            "cargo package --locked", package_check,
+        )
+        positions = [step.find(command) for command in required]
+        if any(step.count(command) != 1 for command in required) or not all(
+            left >= 0 and left < right for left, right in zip(positions, positions[1:])
+        ):
+            errors.append(f"{path}: {header} must validate and package the exact source version")
+        if header == "- name: Package crate" and (
+            "id: package" not in step
+            or 'echo "version=$version" >> "$GITHUB_OUTPUT"' not in step
+        ):
+            errors.append(f"{path}: installed product must export its validated package version")
+    install = _single_yaml_block(
+        path, active, "- name: Install CLI from the exact packaged crate contents",
+        6, "installed package consumer", errors,
+    )
+    for command in (
+        "shell: bash", "set -euo pipefail",
+        "PACKAGE_VERSION: ${{ steps.package.outputs.version }}",
+        'version="$PACKAGE_VERSION"',
+        'cargo install --path "target/package/rxls-${version}" --locked --root target/installed-product',
+    ):
+        if install.count(command) != 1:
+            errors.append(f"{path}: installed consumer must retain {command!r}")
+    if re.search(r"target/package/rxls-[0-9]", active):
+        errors.append(f"{path}: CI must not hardcode a released package version")
+    return errors
+
+
 def audit_core_release_evidence(path: Path, text: str) -> list[str]:
     """Require dry-run and immutable provenance evidence in the public bundle."""
 
     active = _without_commented_lines(text)
     errors: list[str] = []
+    jobs = _single_yaml_block(path, active, "jobs:", 0, "core release jobs", errors)
+    if _yaml_mapping_entries_at_indent(jobs, 2) != [("verify", ""), ("publish", "")]:
+        errors.append(f"{path}: core release must separate verify and publish jobs")
+    verify_job = _single_yaml_block(path, jobs, "verify:", 2, "read-only verification job", errors)
+    publish_job = _single_yaml_block(path, jobs, "publish:", 2, "privileged publication job", errors)
+    for block, indent, expected, label in (
+        (active, 0, [("actions", "read"), ("contents", "read")], "workflow"),
+        (verify_job, 4, [("actions", "read"), ("contents", "read")], "verification"),
+        (publish_job, 4, [("actions", "read"), ("contents", "write")], "publication"),
+    ):
+        permissions = _single_yaml_block(path, block, "permissions:", indent, f"{label} permissions", errors)
+        if _yaml_mapping_entries_at_indent(permissions, indent + 2) != expected:
+            errors.append(f"{path}: core release {label} permissions differ from least privilege")
+    publication_guard = (
+        "github.repository == 'HyunjoJung/rxls' && github.event_name == 'push' "
+        "&& startsWith(github.ref, 'refs/tags/v')"
+    )
+    publication_fields = dict(_yaml_mapping_entries_at_indent(publish_job, 4))
+    for key, expected in (
+        ("needs", "verify"), ("if", publication_guard),
+        ("environment", "crates-io"), ("timeout-minutes", "60"),
+    ):
+        if publication_fields.get(key) != expected:
+            errors.append(f"{path}: core publication must retain exact {key}={expected!r}")
+    if "secrets." in verify_job or "cargo publish --locked --registry" in verify_job:
+        errors.append(f"{path}: verification must not receive secrets or publish packages")
+    if "environment:" in verify_job or "continue-on-error:" in active:
+        errors.append(f"{path}: release verification and publication must fail closed")
+    if active.count("secrets.CARGO_REGISTRY_TOKEN") != 1:
+        errors.append(f"{path}: only the crates.io publication step may receive its secret")
+    for header in (
+        "- name: Run canonical release gate",
+        "- name: Require successful exact-SHA CI and CodeQL runs",
+        "- name: Require exact-SHA two-candidate publication attestation",
+        "- name: Bind publication provenance into release manifest",
+        "- name: Upload verified publication bundle",
+    ):
+        _single_yaml_block(path, verify_job, header, 6, f"read-only {header}", errors)
+    outputs = _single_yaml_block(path, verify_job, "outputs:", 4, "verification outputs", errors)
+    if _yaml_mapping_entries_at_indent(outputs, 6) != [
+        ("version", "${{ steps.release.outputs.version }}"),
+        ("source_attempt", "${{ steps.release.outputs.source_attempt }}"),
+        ("artifact_id", "${{ steps.publication_bundle.outputs.artifact-id }}"),
+        ("artifact_digest", "${{ steps.publication_bundle.outputs.artifact-digest }}"),
+    ]:
+        errors.append(f"{path}: publication handoff must use the exact verified artifact outputs")
     on_block = _single_yaml_block(
         path, active, "on:", 0, "core release trigger block", errors
     )
@@ -2132,7 +2223,7 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
     )
     setup_node_step = _single_yaml_block(
         path,
-        active,
+        verify_job,
         setup_node_header,
         6,
         "core release Node setup step",
@@ -2148,7 +2239,7 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
     checkout_header = f"- uses: {ORACLE_CHECKOUT_ACTION} # v7.0.1"
     checkout_step = _single_yaml_block(
         path,
-        active,
+        verify_job,
         checkout_header,
         6,
         "release checkout step",
@@ -2161,7 +2252,7 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
     step_headers = [
         (match.start(), match.group(1))
         for match in re.finditer(
-            r"^ {6}(- (?:name|uses|run):[^\r\n]+)$", active, re.MULTILINE
+            r"^ {6}(- (?:name|uses|run):[^\r\n]+)$", verify_job, re.MULTILINE
         )
     ]
     checkout_positions = [
@@ -2198,9 +2289,9 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
         errors.append(
             f"{path}: expected exactly one dependency-free crates.io dry-run runner"
         )
-    if len(verify_pattern.findall(active)) != 7:
+    if len(verify_pattern.findall(active)) != 8:
         errors.append(
-            f"{path}: expected seven exact crates.io dry-run evidence verifications"
+            f"{path}: expected eight exact crates.io dry-run evidence verifications"
         )
     if "cargo publish --dry-run" in active:
         errors.append(
@@ -2225,10 +2316,10 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
         errors.append(
             f"{path}: release identity step must bind the tag to exact origin/main"
         )
-    if active.count(exact_main) != 2:
+    if active.count(exact_main) != 3:
         errors.append(
             f"{path}: exact origin/main must be checked at tag validation and again "
-            "immediately before crates.io publication"
+            "at the publication handoff and immediately before crates.io publication"
         )
     if "git merge-base --is-ancestor" in identity_step:
         errors.append(f"{path}: ancestor-only release tag validation is forbidden")
@@ -2255,6 +2346,8 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
         errors.append(f"{path}: release identity must reject shallow history")
     if "scripts/" in identity_step:
         errors.append(f"{path}: release identity must run before repository scripts")
+    if identity_step.count('echo "source_attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"') != 1:
+        errors.append(f"{path}: release identity must export its exact producing attempt")
 
     python_dependencies_step = _single_yaml_block(
         path,
@@ -2323,7 +2416,7 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
                 f"{path}: canonical release gate must verify the shared packaging runtime"
             )
     package_gate = (
-        "python3 scripts/check_core_package.py target/package/rxls-0.1.3.crate"
+        'python3 scripts/check_core_package.py "target/package/rxls-${version}.crate"'
     )
     release_build = "cargo build --release --all-features --locked"
     package_index = canonical_step.find(package_gate)
@@ -2368,6 +2461,11 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
             "- name: Bind publication provenance into release manifest",
             ["dist/release-cargo-publish-dry-run.json"],
             "final publication assembly",
+        ),
+        (
+            "- name: Verify publication handoff and package bytes",
+            ["dist/release-cargo-publish-dry-run.json"],
+            "publication handoff",
         ),
         (
             "- name: Verify published crate, WASM, docs, assets, and checksums",
@@ -2464,9 +2562,9 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
         errors.append(
             f"{path}: candidate bundle must be verified twice at exactly 48 files"
         )
-    if active.count("--expected-files 52") != 3:
+    if active.count("--expected-files 52") != 4:
         errors.append(
-            f"{path}: public bundle must be assembled, published, and downloaded "
+            f"{path}: public bundle must be assembled, transferred, published, and downloaded "
             "at exactly 52 files"
         )
     if re.search(r"--expected-files\s+47\b", active):
@@ -2510,6 +2608,10 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
         "crates.io publication step",
         errors,
     )
+    if _yaml_mapping_entries_at_indent(crates_publish_step, 8).count(
+        ("if", "github.event_name == 'push'")
+    ) != 1 or "CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}" not in crates_publish_step:
+        errors.append(f"{path}: crates.io publication must retain its success-only push guard and step-local token")
     publish_commands = _normalized_active_commands(crates_publish_step)
     prepublication_commands = (
         "git fetch origin main --no-tags",
@@ -2588,6 +2690,109 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
         errors.append(
             f"{path}: wildcard GitHub Release upload must not bypass exact inventory"
         )
+    errors.extend(_audit_core_publication_handoff(path, verify_job, publish_job))
+    return errors
+
+
+def _audit_core_publication_handoff(path: Path, verify_job: str, publish_job: str) -> list[str]:
+    """Keep the privileged job bound to the read-only job's immutable bundle."""
+
+    errors: list[str] = []
+    checkout = _single_yaml_block(path, publish_job, f"- uses: {ORACLE_CHECKOUT_ACTION} # v7.0.1", 6, "publication checkout", errors)
+    for required in ("ref: ${{ github.sha }}", "fetch-depth: 0", "persist-credentials: false"):
+        if checkout.count(required) != 1:
+            errors.append(f"{path}: publication checkout must retain {required!r}")
+    headers = re.findall(r"^ {6}(- (?:name|uses|run):[^\r\n]+)$", publish_job, re.MULTILINE)
+    if len(headers) < 2 or headers[1] != "- name: Validate publication identity":
+        errors.append(f"{path}: publication identity must immediately follow checkout")
+    identity = _single_yaml_block(path, publish_job, "- name: Validate publication identity", 6, "publication identity", errors)
+    for required in (
+        "VERIFIED_VERSION: ${{ needs.verify.outputs.version }}",
+        'test "$GITHUB_REPOSITORY" = "HyunjoJung/rxls"',
+        'test "$GITHUB_EVENT_NAME" = "push"',
+        'test "$GITHUB_REF" = "refs/tags/v$VERIFIED_VERSION"',
+        'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"',
+        'test "$version" = "$VERIFIED_VERSION"',
+        'git fetch origin main --no-tags',
+        'test "$(git rev-parse origin/main)" = "$GITHUB_SHA"',
+        'git fetch origin "refs/tags/$GITHUB_REF_NAME" --no-tags',
+        'test "$(git rev-parse \'FETCH_HEAD^{commit}\')" = "$GITHUB_SHA"',
+        'echo "version=$version" >> "$GITHUB_OUTPUT"',
+    ):
+        if identity.count(required) != 1:
+            errors.append(f"{path}: publication identity must retain {required!r}")
+    upload = _single_yaml_block(path, verify_job, "- name: Upload verified publication bundle", 6, "publication bundle upload", errors)
+    for required in (
+        "id: publication_bundle", "if: github.event_name == 'push'",
+        "name: rxls-${{ steps.release.outputs.version }}-publication-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}",
+        "path: dist/*", "if-no-files-found: error",
+    ):
+        if upload.count(required) != 1:
+            errors.append(f"{path}: publication bundle upload must retain {required!r}")
+    download = _single_yaml_block(path, publish_job, "- name: Download exact verified publication bundle", 6, "publication bundle download", errors)
+    expected_download = [
+        ("artifact-ids", "${{ needs.verify.outputs.artifact_id }}"),
+        ("path", "dist"), ("merge-multiple", "true"), ("digest-mismatch", "error"),
+    ]
+    if _yaml_mapping_entries_at_indent(download, 10) != expected_download:
+        errors.append(f"{path}: publication download must use exact immutable ID and fail on digest mismatch")
+    metadata = _single_yaml_block(path, publish_job, "- name: Authenticate verified publication artifact", 6, "publication artifact authentication", errors)
+    for required in (
+        "GH_TOKEN: ${{ github.token }}",
+        "ARTIFACT_ID: ${{ needs.verify.outputs.artifact_id }}",
+        "ARTIFACT_DIGEST: ${{ needs.verify.outputs.artifact_digest }}",
+        "SOURCE_ATTEMPT: ${{ needs.verify.outputs.source_attempt }}",
+        "VERIFIED_VERSION: ${{ needs.verify.outputs.version }}",
+        '[[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]',
+        'gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID"',
+        'expected_digest = os.environ["ARTIFACT_DIGEST"].removeprefix("sha256:")',
+        'if not re.fullmatch(r"[0-9a-f]{64}", expected_digest):',
+        'if not re.fullmatch(r"[1-9][0-9]*", attempt) or int(attempt) > int(os.environ["GITHUB_RUN_ATTEMPT"]):',
+        'f"rxls-{os.environ[\'VERIFIED_VERSION\']}-publication-"',
+        'f"{os.environ[\'GITHUB_SHA\']}-{os.environ[\'GITHUB_RUN_ID\']}-{attempt}"',
+        '"id": int(os.environ["ARTIFACT_ID"]),',
+        '"name": expected_name,', '"digest": f"sha256:{expected_digest}",',
+        '"expired": False,',
+        'if any(type(artifact.get(key)) is not type(value) or artifact[key] != value for key, value in expected.items()):',
+        '"id": int(os.environ["GITHUB_RUN_ID"]),',
+        '"head_sha": os.environ["GITHUB_SHA"],',
+        '"repository_id": int(os.environ["GITHUB_REPOSITORY_ID"]),',
+        '"head_repository_id": int(os.environ["GITHUB_REPOSITORY_ID"]),',
+        'if not isinstance(run, dict) or any(type(run.get(key)) is not type(value) or run[key] != value for key, value in expected_run.items()):',
+    ):
+        if metadata.count(required) != 1:
+            errors.append(f"{path}: publication artifact authentication must retain {required!r}")
+    handoff = _single_yaml_block(path, publish_job, "- name: Verify publication handoff and package bytes", 6, "publication package handoff", errors)
+    for required in (
+        "python3 scripts/check_workflow_policy.py", "python3 scripts/check_release_identity.py",
+        "--verify-bundle dist", "--expected-files 52",
+        'python3 scripts/check_core_package.py "dist/rxls-${version}.crate"',
+        "cargo package --locked",
+        'cmp "target/package/rxls-${version}.crate" "dist/rxls-${version}.crate"',
+    ):
+        if handoff.count(required) != 1:
+            errors.append(f"{path}: publication package handoff must retain {required!r}")
+    if not (0 <= handoff.find("cargo package --locked") < handoff.find('cmp "target/package/')):
+        errors.append(f"{path}: publication must compare the newly packed crate bytes")
+    ordered_headers = (
+        "- name: Authenticate verified publication artifact",
+        "- name: Download exact verified publication bundle",
+        "- name: Verify publication handoff and package bytes",
+        "- name: Publish to crates.io",
+    )
+    positions = [publish_job.find(header) for header in ordered_headers]
+    if not all(left >= 0 and left < right for left, right in zip(positions, positions[1:])):
+        errors.append(f"{path}: publication must authenticate, download, and verify before publishing")
+    for block in (identity, metadata, handoff):
+        if "set -euo pipefail" not in block or re.search(r"^ {8}if:", block, re.MULTILINE):
+            errors.append(f"{path}: critical publication gates must run unconditionally and fail closed")
+    if re.search(r"^ {8}if:", download, re.MULTILINE):
+        errors.append(f"{path}: publication download must not be conditionally skipped")
+    for block in (verify_job, publish_job):
+        if "rxls-0.1.3" in block or "--registry-version 0.1.3" in block:
+            errors.append(f"{path}: release package names and registry smokes must use validated version")
+    if '"$smoke/assets/wasm-native-report.json"' not in publish_job:
+        errors.append(f"{path}: installed browser smoke must use the verified native report")
     return errors
 
 
@@ -6419,6 +6624,7 @@ def audit_repository(root: Path) -> list[str]:
             errors.extend(audit_semver_gate(relative, text))
         if path.name == "ci.yml":
             errors.extend(audit_ci_feature_matrix(relative, text))
+            errors.extend(audit_ci_package_versions(relative, text))
         if path.name == "render-oracle.yml":
             errors.extend(audit_render_oracle_workflow(relative, text))
         elif path.name == "render-hardening.yml":

--- a/scripts/test_release_tools.py
+++ b/scripts/test_release_tools.py
@@ -369,14 +369,30 @@ class ReleaseToolTests(unittest.TestCase):
         registry_index = workflow.index("name: Smoke published crates.io distribution")
         self.assertLess(local_index, assembly_index)
         self.assertLess(publish_index, registry_index)
-        self.assertIn("--crate target/package/rxls-0.1.3.crate", workflow)
-        self.assertIn("--registry-version 0.1.3", workflow)
+        self.assertIn('--crate "target/package/rxls-${version}.crate"', workflow)
+        self.assertIn('--registry-version "$version"', workflow)
+        self.assertNotIn("rxls-0.1.3", workflow)
         self.assertIn("dist/release-crate-distribution-smoke.json", workflow)
         registry_upload = workflow.index(
             "name: Upload published crates.io distribution evidence"
         )
         self.assertGreater(registry_upload, registry_index)
         self.assertIn("target/release-crates-io-distribution-smoke.json", workflow)
+
+    def test_release_separates_read_only_verification_from_publication(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        verification = workflow.split("  verify:\n", 1)[1].split("  publish:\n", 1)[0]
+        publication = workflow.split("  publish:\n", 1)[1]
+        self.assertIn("  contents: read\n", workflow.split("concurrency:", 1)[0])
+        self.assertNotIn("contents: write", verification)
+        self.assertNotIn("secrets.", verification)
+        self.assertIn("needs: verify", publication)
+        self.assertIn("environment: crates-io", publication)
+        self.assertIn("artifact-ids: ${{ needs.verify.outputs.artifact_id }}", publication)
+        self.assertIn("digest-mismatch: error", publication)
+        compare = publication.index('cmp "target/package/rxls-${version}.crate"')
+        self.assertLess(compare, publication.index("name: Publish to crates.io"))
+        self.assertIn('"$smoke/assets/wasm-native-report.json"', publication)
 
     def test_hosted_candidate_release_bundle_contract_is_exactly_48_files(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")

--- a/scripts/test_workflow_policy.py
+++ b/scripts/test_workflow_policy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import hashlib
+import json
 import os
 import re
 import subprocess
@@ -601,6 +602,75 @@ steps:
                         Path("release.yml"), workflow
                     )
                 )
+
+    def test_core_release_privilege_handoff_is_mutation_guarded(self) -> None:
+        original = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        replacements = {
+            "workflow_write": ("permissions:\n  actions: read\n  contents: read", "permissions:\n  actions: read\n  contents: write"),
+            "verification_write": ("      contents: read\n    outputs:", "      contents: write\n    outputs:"),
+            "publication_dependency": ("    needs: verify", "    needs: []"),
+            "publication_environment": ("    environment: crates-io", "    environment: unprotected"),
+            "publication_event": ("if: github.repository == 'HyunjoJung/rxls' && github.event_name == 'push'", "if: github.repository == 'HyunjoJung/rxls' && github.event_name != 'push'"),
+            "publication_source": ("          ref: ${{ github.sha }}", "          ref: main"),
+            "publication_tag": ('test "$GITHUB_REF" = "refs/tags/v$VERIFIED_VERSION"', "true"),
+            "publication_version": ('test "$version" = "$VERIFIED_VERSION"', "true"),
+            "artifact_output": ("artifact_id: ${{ steps.publication_bundle.outputs.artifact-id }}", "artifact_id: 1234"),
+            "artifact_input": ("artifact-ids: ${{ needs.verify.outputs.artifact_id }}", "name: latest-release"),
+            "artifact_digest_mode": ("digest-mismatch: error", "digest-mismatch: warn"),
+            "artifact_digest": ('"digest": f"sha256:{expected_digest}",', '"digest": artifact["digest"],'),
+            "artifact_run": ('"id": int(os.environ["GITHUB_RUN_ID"]),', '"id": 123,'),
+            "artifact_sha": ('"head_sha": os.environ["GITHUB_SHA"],', '"head_sha": "main",'),
+            "artifact_repository": ('"head_repository_id": int(os.environ["GITHUB_REPOSITORY_ID"]),', '"head_repository_id": 123,'),
+            "artifact_expired": ('"expired": False,', '"expired": True,'),
+            "archive_bytes": ('cmp "target/package/rxls-${version}.crate" "dist/rxls-${version}.crate"', "true"),
+            "handoff_skip": ("      - name: Verify publication handoff and package bytes\n", "      - name: Verify publication handoff and package bytes\n        if: false\n"),
+            "publish_after_failure": ("      - name: Publish to crates.io\n        if: github.event_name == 'push'", "      - name: Publish to crates.io\n        if: always() && github.event_name == 'push'"),
+            "stale_version": ('--registry-version "$version"', "--registry-version 0.1.3"),
+        }
+        self.assertEqual(self.policy.audit_core_release_evidence(Path("release.yml"), original), [])
+        for label, (old, new) in replacements.items():
+            with self.subTest(mutation=label):
+                mutated = original.replace(old, new, 1)
+                self.assertNotEqual(original, mutated)
+                self.assertTrue(self.policy.audit_core_release_evidence(Path("release.yml"), mutated))
+
+    def test_core_release_artifact_metadata_authentication(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        step = workflow.split("      - name: Authenticate verified publication artifact\n", 1)[1].split("      - name:", 1)[0]
+        script = textwrap.dedent(step.split("python3 - <<'PY'\n", 1)[1].rsplit("          PY", 1)[0])
+        environment = {
+            "ARTIFACT_ID": "456", "ARTIFACT_DIGEST": "a" * 64,
+            "SOURCE_ATTEMPT": "1", "VERIFIED_VERSION": "0.1.4",
+            "GITHUB_RUN_ID": "123", "GITHUB_RUN_ATTEMPT": "2",
+            "GITHUB_SHA": "b" * 40, "GITHUB_REPOSITORY_ID": "789",
+        }
+        metadata = {
+            "id": 456, "name": f"rxls-0.1.4-publication-{'b' * 40}-123-1",
+            "digest": f"sha256:{'a' * 64}", "expired": False,
+            "workflow_run": {"id": 123, "head_sha": "b" * 40, "repository_id": 789, "head_repository_id": 789},
+        }
+
+        def authenticate(data, env):
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(Path, "read_text", return_value=json.dumps(data)):
+                exec(compile(script, "release-artifact-authentication", "exec"), {})
+
+        # A publication-only rerun may reuse its successful verification job's
+        # exact earlier attempt, never a name-selected latest artifact.
+        authenticate(metadata, environment)
+        authenticate(metadata, {**environment, "ARTIFACT_DIGEST": f"sha256:{'a' * 64}"})
+        for key, value in (
+            ("id", 457), ("id", True), ("expired", True),
+            ("name", metadata["name"].replace("-123-1", "-123-2")),
+            ("digest", f"sha256:{'c' * 64}"), ("workflow_run", None),
+        ):
+            with self.subTest(field=key, value=value), self.assertRaises(SystemExit):
+                authenticate({**metadata, key: value}, environment)
+        for key in metadata["workflow_run"]:
+            with self.subTest(run_field=key), self.assertRaises(SystemExit):
+                authenticate({**metadata, "workflow_run": {**metadata["workflow_run"], key: "wrong"}}, environment)
+        for key, value in (("SOURCE_ATTEMPT", "0"), ("SOURCE_ATTEMPT", "3"), ("ARTIFACT_DIGEST", "invalid")):
+            with self.subTest(environment=key), self.assertRaises(SystemExit):
+                authenticate(metadata, {**environment, key: value})
 
     def test_github_release_reconciler_invariants_are_mutation_guarded(self) -> None:
         path = Path("scripts/reconcile_github_release.py")
@@ -3978,11 +4048,11 @@ steps:
         self.assertIn("cargo test --test cli --locked", workflow)
         self.assertIn("cargo package --locked", workflow)
         self.assertIn(
-            "python3 scripts/check_core_package.py target/package/rxls-0.1.3.crate",
+            'python3 scripts/check_core_package.py "target/package/rxls-${version}.crate"',
             workflow,
         )
         self.assertIn(
-            "cargo install --path target/package/rxls-0.1.3 --locked --root target/installed-product",
+            'cargo install --path "target/package/rxls-${version}" --locked --root target/installed-product',
             workflow,
         )
         self.assertIn('installed="target/installed-product/bin/', workflow)
@@ -3992,11 +4062,24 @@ steps:
 
         self.assertEqual(
             workflow.count(
-                "python3 scripts/check_core_package.py target/package/rxls-0.1.3.crate"
+                'python3 scripts/check_core_package.py "target/package/rxls-${version}.crate"'
             ),
             2,
         )
         self.assertNotIn("target/package/rxls-0.1.2", workflow)
+        self.assertNotIn("target/package/rxls-0.1.3", workflow)
+        self.assertEqual(self.policy.audit_ci_package_versions(Path("ci.yml"), workflow), [])
+        mutations = (
+            ('python3 scripts/check_core_package.py "target/package/rxls-${version}.crate"', 'python3 scripts/check_core_package.py target/package/rxls-0.1.3.crate'),
+            ('PACKAGE_VERSION: ${{ steps.package.outputs.version }}', 'PACKAGE_VERSION: 0.1.3'),
+            ('cargo install --path "target/package/rxls-${version}"', 'cargo install --path .'),
+            ('      - name: Package crate\n        id: package\n        shell: bash', '      - name: Package crate\n        id: package\n        shell: pwsh'),
+        )
+        for old, new in mutations:
+            with self.subTest(mutation=old):
+                changed = workflow.replace(old, new, 1)
+                self.assertNotEqual(changed, workflow)
+                self.assertTrue(self.policy.audit_ci_package_versions(Path("ci.yml"), changed))
 
 
 if __name__ == "__main__":

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -11,7 +11,9 @@ and ODS stay read-only.
 In the current source build, click a rendered cell once in editable sheet view
 to edit it directly,
 or edit its value in the formula bar. Enter commits and moves down; Tab commits
-and moves across; Escape cancels the draft. A leading `=` enters a formula.
+and moves across; Escape cancels the draft. Tab at the last cell and Shift+Tab
+at the first cell leave the worksheet after any draft is successfully saved.
+A leading `=` enters a formula.
 The typed-cell dialog remains available for explicit value kinds and cached
 formula values.
 

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -434,7 +434,9 @@
             <p id="grid-help" class="visually-hidden">
               Click a cell once to edit its existing value. Select all to
               replace it. Enter applies an edit, Tab moves to the next cell, and
-              Escape cancels. Prefix text with an apostrophe to keep it as text.
+              Escape cancels. At the last cell, Tab leaves the worksheet;
+              Shift+Tab at the first cell moves back to the preceding control.
+              Prefix text with an apostrophe to keep it as text.
               Dates use Excel serial values. Formula calculation supports a
               limited deterministic subset.
             </p>

--- a/viewer/src/editing.js
+++ b/viewer/src/editing.js
@@ -27,6 +27,12 @@ export function createEditingController({
   const cellReads = createLatestRequestGate();
   let mutationPending = false;
   let recalculationWarning = "";
+  let warningContext = null;
+  let warningSummary = null;
+  const warningUndo = [];
+  const warningRedo = [];
+  // Match the worker's bounded edit history; retain counts, never workbook text.
+  const maxWarningHistory = 20;
   const editing = {
     cellReadTarget: null,
     cellReadPending: false,
@@ -98,6 +104,7 @@ export function createEditingController({
   }
 
   function updateEditUi() {
+    syncWarningContext();
     const editState = state.editState;
     const editable = editState?.capability === "read-write";
     const hostReadOnly = Boolean(state.workbook && readOnly);
@@ -403,24 +410,32 @@ export function createEditingController({
     if (!canEditWorkbook()) {
       return;
     }
+    const target = currentTarget();
+    mutationPending = true;
     try {
       setFormPending(elements["properties-form"], true);
+      setBusy(true, "Updating document properties");
       const properties = Object.fromEntries(
         propertyFields().map(([property, elementId]) => [
           property,
           elements[elementId].value || null,
         ]),
       );
-      const result = await state.client.setDocumentProperties(
-        state.documentId,
+      const result = await target.client.setDocumentProperties(
+        target.documentId,
         properties,
       );
+      if (!isCurrentTarget(target)) return;
       closePropertiesEditor();
-      await applyMutationResult(result, "Document properties updated");
+      await applyMutationResult(result, "Document properties updated", target);
     } catch (error) {
-      showError(error);
+      if (isCurrentTarget(target)) showError(error);
     } finally {
+      mutationPending = false;
       setFormPending(elements["properties-form"], false);
+      if (isCurrentTarget(target)) {
+        setBusy(false);
+      }
     }
   }
 
@@ -430,46 +445,56 @@ export function createEditingController({
     if (!canEditWorkbook()) {
       return;
     }
+    const target = currentTarget();
     try {
       setBusy(true, direction === "undo" ? "Undoing edit" : "Redoing edit");
       const result =
         direction === "undo"
-          ? await state.client.undoEdit(state.documentId)
-          : await state.client.redoEdit(state.documentId);
+          ? await target.client.undoEdit(target.documentId)
+          : await target.client.redoEdit(target.documentId);
       await applyMutationResult(
         result,
         direction === "undo" ? "Edit undone" : "Edit redone",
+        target,
+        direction,
       );
     } catch (error) {
-      setBusy(false);
-      showError(error);
+      if (isCurrentTarget(target)) {
+        setBusy(false);
+        showError(error);
+      }
     }
   }
 
-  async function applyMutationResult(result, message, target = null) {
-    if (target && !isCurrentTarget(target)) return false;
+  async function applyMutationResult(
+    result,
+    message,
+    target,
+    history = "edit",
+  ) {
+    if (!isCurrentTarget(target)) return false;
+    syncWarningContext();
+    const report = updateWarningHistory(result, history);
     state.workbook = result.workbook;
     state.editState = result.editState;
     state.manifests.clear();
-    state.pageIndex = 0;
+    // Pagination may change; renderCurrent clamps against the refreshed manifest.
     state.sheetIndex = Math.min(
       state.sheetIndex,
       Math.max(0, state.workbook.sheetCount - 1),
     );
     updateWorkbookUi();
     await renderCurrent({ fit: false });
-    if (!target || isCurrentTarget(target)) {
+    if (isCurrentTarget(target)) {
       elements["status-message"].textContent = summarizeRecalculation(
-        result.recalculation,
+        report,
         message,
       );
     }
-    return !target || isCurrentTarget(target);
+    return isCurrentTarget(target);
   }
 
-  function summarizeRecalculation(report, message) {
-    // This is a successful edit with an explicit cached-value fallback, not a failed edit.
-    // Never display formulas or workbook text from a recalculation diagnostic.
+  function clearWarning() {
     if (
       recalculationWarning &&
       elements["error-message"].textContent === recalculationWarning
@@ -477,7 +502,51 @@ export function createEditingController({
       elements["error-banner"].hidden = true;
       elements["error-message"].textContent = "";
     }
+    if (
+      recalculationWarning &&
+      elements["status-message"].textContent === recalculationWarning
+    ) {
+      elements["status-message"].textContent = "";
+    }
     recalculationWarning = "";
+  }
+
+  function syncWarningContext() {
+    if (
+      state.workbook &&
+      warningContext &&
+      warningContext.client === state.client &&
+      warningContext.documentId === state.documentId
+    )
+      return;
+    clearWarning();
+    warningSummary = null;
+    warningUndo.length = warningRedo.length = 0;
+    warningContext = state.workbook ? currentTarget() : null;
+  }
+
+  function updateWarningHistory(result, direction) {
+    if (direction === "undo" || direction === "redo") {
+      const source = direction === "undo" ? warningUndo : warningRedo;
+      const destination = direction === "undo" ? warningRedo : warningUndo;
+      destination.push(warningSummary);
+      // If an older snapshot was evicted, retain uncertainty rather than claiming clean caches.
+      if (source.length) warningSummary = source.pop();
+    } else {
+      warningUndo.push(warningSummary);
+      warningRedo.length = 0;
+    }
+    for (const [entries, depth] of [
+      [warningUndo, result.editState?.undoDepth],
+      [warningRedo, result.editState?.redoDepth],
+    ]) {
+      const limit =
+        Number.isSafeInteger(depth) && depth >= 0
+          ? Math.min(depth, maxWarningHistory)
+          : maxWarningHistory;
+      entries.splice(0, Math.max(0, entries.length - limit));
+    }
+    const report = result.recalculation;
     if (
       !report ||
       !Number.isSafeInteger(report.computedCells) ||
@@ -485,7 +554,26 @@ export function createEditingController({
       !Number.isSafeInteger(report.unsupportedCells) ||
       report.unsupportedCells < 0
     )
-      return message;
+      return null;
+    const summary = {
+      computedCells: report.computedCells,
+      unsupportedCells: report.unsupportedCells,
+    };
+    warningSummary = summary.unsupportedCells > 0 ? summary : null;
+    return summary;
+  }
+
+  function summarizeRecalculation(report, message) {
+    // Metadata/history do not recalculate; an absent report must not claim clean caches.
+    clearWarning();
+    if (!report && !warningSummary) return message;
+    if (!report) {
+      const count = warningSummary.unsupportedCells;
+      recalculationWarning = `${message}. ${count} unsupported formula cell${count === 1 ? " still uses" : "s still use"} cached values.`;
+      elements["error-message"].textContent = recalculationWarning;
+      elements["error-banner"].hidden = false;
+      return recalculationWarning;
+    }
     const computed = `${report.computedCells} formula cell${report.computedCells === 1 ? "" : "s"} recalculated`;
     if (report.unsupportedCells === 0) return `${message}. ${computed}.`;
     const unsupported = `${report.unsupportedCells} unsupported formula cell${report.unsupportedCells === 1 ? "" : "s"}`;
@@ -553,6 +641,14 @@ export function createEditingController({
         target.documentId === state.documentId &&
         target.sheetIndex === state.sheetIndex,
     );
+  }
+
+  function currentTarget() {
+    return {
+      client: state.client,
+      documentId: state.documentId,
+      sheetIndex: state.sheetIndex,
+    };
   }
 
   function cellReference(row, col) {

--- a/viewer/src/grid-editor.js
+++ b/viewer/src/grid-editor.js
@@ -118,6 +118,7 @@ export function createGridEditor({
   elements,
   onSelection = () => {},
   onDraft = () => {},
+  focusOutsideGrid = () => false,
   showError,
   readOnly = false,
 }) {
@@ -525,6 +526,8 @@ export function createGridEditor({
       cancel();
       return true;
     }
+    const ownerDocument = input.ownerDocument;
+    const hadInputFocus = ownerDocument?.activeElement === input;
     try {
       const value = inlineCellValue(input.value, current.original);
       committing = true;
@@ -549,6 +552,19 @@ export function createGridEditor({
     } finally {
       committing = false;
       update();
+      // Disabling a focused native textarea blurs it. Keep failed edits keyboard-retryable,
+      // without stealing focus from a toolbar command or a newer document/control.
+      if (
+        draft === current &&
+        sameContext(current.target) &&
+        hadInputFocus &&
+        available() &&
+        !input.disabled &&
+        !input.hidden &&
+        (ownerDocument.activeElement === ownerDocument.body ||
+          ownerDocument.activeElement === input)
+      )
+        input.focus({ preventScroll: true });
       if (!draft && available()) void readSelected();
     }
   }
@@ -585,16 +601,8 @@ export function createGridEditor({
   function adjacent(direction) {
     if (!selected) return null;
     if (direction === "next" || direction === "previous") {
-      return cells[
-        Math.max(
-          0,
-          Math.min(
-            cells.length - 1,
-            cells.findIndex((cell) => cell.key === selected.key) +
-              (direction === "next" ? 1 : -1),
-          ),
-        )
-      ];
+      const index = cells.findIndex((cell) => cell.key === selected.key);
+      return cells[index + (direction === "next" ? 1 : -1)] ?? null;
     }
     const x = selected.x + Math.min(1, selected.width / 2);
     const y = selected.y + Math.min(1, selected.height / 2);
@@ -662,7 +670,30 @@ export function createGridEditor({
           : event.shiftKey
             ? "up"
             : "down";
-      if (await commit()) {
+      const target = { ...snapshot(), key: selected.key };
+      const exit = event.key === "Tab" && !adjacent(direction);
+      const ownerDocument = input.ownerDocument;
+      const activeElement = ownerDocument?.activeElement;
+      if (
+        (await commit()) &&
+        available() &&
+        sameContext(target) &&
+        (selected?.key === target.key || (exit && !selected))
+      ) {
+        if (exit) {
+          // The native Tab action cannot resume after an asynchronous commit.
+          // Move to an actual outside control, unless the user moved focus meanwhile.
+          const currentFocus = ownerDocument?.activeElement;
+          if (
+            !ownerDocument ||
+            currentFocus === activeElement ||
+            currentFocus === input ||
+            currentFocus === surface ||
+            currentFocus === ownerDocument.body
+          )
+            focusOutsideGrid(direction);
+          return;
+        }
         const next = adjacent(direction);
         if (next) await select(next.row, next.col);
       }

--- a/viewer/src/main.js
+++ b/viewer/src/main.js
@@ -257,8 +257,40 @@ grid = createGridEditor({
     void workbench.selectCell(selection);
   },
   onDraft: (draft) => workbench.setDraft(draft),
+  focusOutsideGrid,
   showError,
 });
+
+function focusOutsideGrid(direction) {
+  const surface = elements["document-surface"];
+  // Resolve the current tab order after a commit: rendering may replace controls.
+  const stops = [
+    ...document.querySelectorAll(
+      "a[href], button, input, select, textarea, summary, [tabindex]",
+    ),
+  ]
+    .filter(
+      (element) =>
+        (element === surface || !surface.contains(element)) &&
+        element.tabIndex >= 0 &&
+        !element.matches(":disabled") &&
+        !element.closest("[hidden], [inert]") &&
+        element.getClientRects().length > 0 &&
+        getComputedStyle(element).visibility === "visible",
+    )
+    .sort((a, b) => {
+      if (a.tabIndex === b.tabIndex) return 0;
+      if (a.tabIndex === 0) return 1;
+      if (b.tabIndex === 0) return -1;
+      return a.tabIndex - b.tabIndex;
+    });
+  const index = stops.indexOf(surface);
+  if (index < 0 || !["next", "previous"].includes(direction)) return false;
+  const target = stops[index + (direction === "next" ? 1 : -1)];
+  if (!target) return false;
+  target.focus();
+  return document.activeElement === target;
+}
 
 bindEvents();
 setBusy(true, "Starting renderer");

--- a/viewer/tests/browser.mjs
+++ b/viewer/tests/browser.mjs
@@ -9,7 +9,7 @@ import {
   PRESERVATION_FIXTURE,
   PRESERVED_PARTS,
 } from "../scripts/preservation-fixture.mjs";
-import { readZipEntries } from "../scripts/zip.mjs";
+import { createStoredZip, readZipEntries } from "../scripts/zip.mjs";
 
 const execFileAsync = promisify(execFile);
 const port = Number(process.env.RXLS_VIEWER_PORT || 4173);
@@ -172,6 +172,7 @@ try {
   );
 
   await exerciseInlineEditing(page);
+  await exerciseMutationContinuity(page);
 
   const state = await page.evaluate(() => globalThis.__rxlsViewerState());
   if (
@@ -611,7 +612,11 @@ try {
   await page.locator("#page-view").click();
   await page.locator("#page-controls").waitFor({ state: "visible" });
   await page.locator("#document-surface svg").waitFor({ state: "visible" });
-  const pageState = await page.evaluate(() => globalThis.__rxlsViewerState());
+  const pageState = await waitForViewerState(
+    page,
+    (value) => value.mode === "page" && !value.busy && value.rendered,
+    "initial print preview rendered",
+  );
   if (pageState.mode !== "page" || pageState.pageIndex !== 0) {
     throw new Error(`page mode did not settle: ${JSON.stringify(pageState)}`);
   }
@@ -840,6 +845,50 @@ async function exerciseInlineEditing(page) {
     "reverse Tab navigation",
   );
 
+  await select("A1", "Q3 Operations Snapshot");
+  await input.press("Shift+Tab");
+  await waitForCondition(
+    () =>
+      page
+        .locator("#viewer-viewport")
+        .evaluate((element) => document.activeElement === element),
+    "Shift+Tab exits the first cell to the preceding focus stop",
+  );
+
+  await select("E10");
+  await input.click();
+  await input.fill("Last cell saved before leaving");
+  await input.press("Tab");
+  await waitForCondition(
+    () =>
+      page
+        .locator('#sheet-list button[data-index="0"]')
+        .evaluate((element) => document.activeElement === element),
+    "Tab commits the last cell and focuses the next outside control",
+  );
+  await select("E10", "Last cell saved before leaving");
+  await undo();
+  await select("E10");
+  await input.click();
+  await input.fill("=UNKNOWNFUNCTION(1)");
+  await input.press("Tab");
+  await page.locator("#error-banner").waitFor({ state: "visible" });
+  await waitForCondition(
+    async () => !(await input.isDisabled()),
+    "failed edge commit settled",
+  );
+  assert.equal(await input.inputValue(), "=UNKNOWNFUNCTION(1)");
+  assert.equal(
+    await input.evaluate((element) => document.activeElement === element),
+    true,
+  );
+  assert.equal(
+    (await page.evaluate(() => globalThis.__rxlsViewerState())).dirty,
+    false,
+  );
+  await input.press("Escape");
+  await page.locator("#dismiss-error").click();
+
   await select("C4", "420000");
   await input.click();
   assert.equal(await input.inputValue(), "420000");
@@ -962,6 +1011,165 @@ async function exerciseInlineEditing(page) {
     (value) => !value.busy && value.mode === "sheet",
     "interactive sheet restored",
   );
+}
+
+async function exerciseMutationContinuity(page) {
+  // Derive a bounded, project-owned workbook in memory: multiple print pages
+  // and one unsupported formula whose existing cache must remain explicit.
+  const entries = readZipEntries(
+    await readFile(
+      new URL("../samples/operations-report.xlsx", import.meta.url),
+    ),
+  );
+  const sheetName = "xl/worksheets/sheet1.xml";
+  entries.set(
+    sheetName,
+    Buffer.from(
+      entries
+        .get(sheetName)
+        .toString()
+        .replace('fitToPage="1"', 'fitToPage="0"')
+        .replace(/<pageSetup[^>]*\/>/, '<pageSetup paperSize="9" scale="100"/>')
+        .replace(
+          "</sheetData>",
+          '<row r="80"><c r="E80"><f>UNKNOWNFUNCTION(1)</f><v>7</v></c></row></sheetData>',
+        ),
+    ),
+  );
+  entries.set(
+    "xl/workbook.xml",
+    Buffer.from(
+      entries
+        .get("xl/workbook.xml")
+        .toString()
+        .replace("'Operations'!$A$1:$E$10", "'Operations'!$A$1:$E$80"),
+    ),
+  );
+  await page.locator("#file-input").setInputFiles({
+    name: "mutation-continuity.xlsx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    buffer: createStoredZip(
+      [...entries].map(([name, data]) => ({ name, data })),
+    ),
+  });
+  await waitForViewerState(
+    page,
+    (value) => value.fileName === "mutation-continuity.xlsx" && !value.busy,
+    "continuity workbook opened",
+  );
+  await page.locator("#page-view").click();
+  await waitForViewerState(
+    page,
+    (value) => value.mode === "page" && !value.busy,
+    "continuity pages prepared",
+  );
+  assert.equal(
+    await page.locator("#next-page").isDisabled(),
+    false,
+    "fixture has multiple pages",
+  );
+  await page.locator("#next-page").click();
+  await waitForViewerState(
+    page,
+    (value) => value.pageIndex === 1 && !value.busy,
+    "second print page",
+  );
+
+  await page.locator("#edit-cell").click();
+  await page.locator("#cell-dialog").waitFor({ state: "visible" });
+  await page.locator("#cell-reference").fill("C4");
+  await page.locator("#read-cell").click();
+  await waitForCondition(
+    async () => !(await page.locator("#apply-cell-edit").isDisabled()),
+    "continuity cell ready",
+  );
+  await page.locator("#cell-value").fill("125000");
+  await page.locator("#apply-cell-edit").click();
+  await waitForViewerState(
+    page,
+    (value) => value.dirty && !value.busy,
+    "second-page cell mutation",
+  );
+  assert.equal(
+    (await page.evaluate(() => globalThis.__rxlsViewerState())).pageIndex,
+    1,
+  );
+  await page.locator("#error-banner").waitFor({ state: "visible" });
+  const assertCachedWarning = async () => {
+    assert.equal(await page.locator("#error-banner").isHidden(), false);
+    assert.match(
+      await page.locator("#error-message").textContent(),
+      /1 unsupported formula cell.*cached value/i,
+    );
+  };
+  await assertCachedWarning();
+
+  await page.locator("#document-properties").click();
+  await page.locator("#properties-dialog").waitFor({ state: "visible" });
+  await page
+    .locator("#property-title")
+    .fill("Metadata does not recalculate formulas");
+  await page.locator('#properties-form button[type="submit"]').click();
+  await waitForCondition(
+    () => page.locator("#properties-dialog").isHidden(),
+    "metadata submitted",
+  );
+  await waitForViewerState(page, (value) => !value.busy, "metadata rendered");
+  assert.equal(
+    (await page.evaluate(() => globalThis.__rxlsViewerState())).pageIndex,
+    1,
+  );
+  await assertCachedWarning();
+
+  await page.locator("#undo-edit").click();
+  await waitForViewerState(
+    page,
+    (value) => !value.busy && value.canRedo,
+    "metadata undo",
+  );
+  assert.equal(
+    (await page.evaluate(() => globalThis.__rxlsViewerState())).pageIndex,
+    1,
+  );
+  await assertCachedWarning();
+  await page.locator("#undo-edit").click();
+  await waitForViewerState(
+    page,
+    (value) => !value.busy && !value.dirty,
+    "cell undo clears stale-cache warning",
+  );
+  assert.equal(await page.locator("#error-banner").isHidden(), true);
+  await page.locator("#redo-edit").click();
+  await waitForViewerState(
+    page,
+    (value) => !value.busy && value.dirty,
+    "cell redo restores stale-cache warning",
+  );
+  await assertCachedWarning();
+  assert.equal(
+    (await page.evaluate(() => globalThis.__rxlsViewerState())).pageIndex,
+    1,
+  );
+  await page.locator("#undo-edit").click();
+  await waitForViewerState(
+    page,
+    (value) => !value.busy && !value.dirty,
+    "continuity source restored",
+  );
+  await selectSample(page, "operations-report");
+  await waitForViewerState(
+    page,
+    (value) => value.fileName === "operations-report.xlsx" && !value.busy,
+    "original sample restored",
+  );
+  await page.locator("#sheet-view").click();
+  await waitForViewerState(
+    page,
+    (value) => value.mode === "sheet" && !value.busy,
+    "original sheet view restored",
+  );
+  assert.equal(await page.locator("#error-banner").isHidden(), true);
 }
 
 async function builtBasePath() {

--- a/viewer/tests/editing.test.mjs
+++ b/viewer/tests/editing.test.mjs
@@ -40,7 +40,12 @@ function deferred() {
   return { promise, resolve, reject };
 }
 
-function setup({ readOnly = false, client = {}, beforeCommand } = {}) {
+function setup({
+  readOnly = false,
+  client = {},
+  beforeCommand,
+  renderCurrent,
+} = {}) {
   const elements = new Proxy(
     {},
     {
@@ -93,6 +98,7 @@ function setup({ readOnly = false, client = {}, beforeCommand } = {}) {
     },
     renderCurrent: async (options) => {
       calls.renders.push(options);
+      await renderCurrent?.(state);
       state.busy = false;
     },
     download: (blob, name) => calls.downloads.push({ blob, name }),
@@ -205,7 +211,7 @@ test("a loaded cell submits a typed edit and refreshes the rendered workbook", a
   assert.equal(elements["cell-dialog"].open, false);
   assert.equal(state.editState.dirty, true);
   assert.equal(state.manifests.size, 0);
-  assert.equal(state.pageIndex, 0);
+  assert.equal(state.pageIndex, 3);
   assert.deepEqual(calls.renders, [{ fit: false }]);
   assert.equal(elements["status-message"].textContent, "A1 updated");
 });
@@ -535,6 +541,289 @@ test("a fully recalculated later edit clears its previous unsupported warning", 
     fixture.elements["status-message"].textContent,
     "A1 updated. 1 formula cell recalculated.",
   );
+});
+
+function warningFixture() {
+  const fixture = setup();
+  fixture.state.client.setCellAndRecalculate = async () => ({
+    workbook: fixture.workbook,
+    editState: { ...fixture.state.editState, dirty: true },
+    recalculation: {
+      computedCells: 4,
+      unchangedCells: 2,
+      unsupportedCells: 1,
+      reasons: ["unsupported_function"],
+    },
+  });
+  fixture.state.client.setDocumentProperties = async () => ({
+    workbook: fixture.workbook,
+    editState: fixture.state.editState,
+  });
+  fixture.state.client.undoEdit = fixture.state.client.redoEdit = async () => ({
+    workbook: fixture.workbook,
+    editState: fixture.state.editState,
+  });
+  fixture.commit = () =>
+    fixture.controller.commitCellEdit(
+      {
+        client: fixture.state.client,
+        documentId: fixture.state.documentId,
+        sheetIndex: fixture.state.sheetIndex,
+        row: 0,
+        col: 0,
+      },
+      { kind: "number", value: 7 },
+    );
+  fixture.properties = async () => {
+    await fixture.controller.openPropertiesEditor();
+    fixture.elements["property-title"].value = "Updated title";
+    fixture.elements["properties-form"].emit("submit");
+    await flush();
+  };
+  return fixture;
+}
+
+test("metadata edits retain the current page and existing cached-formula warning", async () => {
+  const fixture = warningFixture();
+  await fixture.commit();
+  fixture.state.pageIndex = 3;
+  await fixture.properties();
+  assert.equal(fixture.state.pageIndex, 3);
+  assert.equal(fixture.elements["error-banner"].hidden, false);
+  assert.match(
+    fixture.elements["error-message"].textContent,
+    /1 unsupported formula cell/,
+  );
+  assert.doesNotMatch(
+    fixture.elements["status-message"].textContent,
+    /recalculated/,
+  );
+  assert.deepEqual(fixture.calls.errors, []);
+});
+
+test("undo and redo restore cached-formula warning state without changing pages", async () => {
+  const fixture = warningFixture();
+  await fixture.commit();
+  await fixture.properties();
+  for (const [direction, warning] of [
+    ["undo", true],
+    ["undo", false],
+    ["redo", true],
+    ["redo", true],
+  ]) {
+    fixture.state.pageIndex = 3;
+    await fixture.controller.applyHistoryEdit(direction);
+    assert.equal(fixture.state.pageIndex, 3);
+    assert.equal(fixture.elements["error-banner"].hidden, !warning, direction);
+    assert.doesNotMatch(
+      fixture.elements["status-message"].textContent,
+      /recalculated/,
+    );
+  }
+});
+
+test("undo restores a prior warning after a fully recalculated edit and redo clears it", async () => {
+  const fixture = warningFixture();
+  await fixture.commit();
+  fixture.state.client.setCellAndRecalculate = async () => ({
+    workbook: fixture.workbook,
+    editState: fixture.state.editState,
+    recalculation: {
+      computedCells: 2,
+      unchangedCells: 0,
+      unsupportedCells: 0,
+      reasons: [],
+    },
+  });
+  await fixture.commit();
+  assert.equal(fixture.elements["error-banner"].hidden, true);
+  await fixture.controller.applyHistoryEdit("undo");
+  assert.equal(fixture.elements["error-banner"].hidden, false);
+  await fixture.controller.applyHistoryEdit("redo");
+  assert.equal(fixture.elements["error-banner"].hidden, true);
+});
+
+test("warning history follows worker snapshot eviction and new edit branches", async () => {
+  const fixture = warningFixture();
+  await fixture.commit();
+  fixture.state.client.setDocumentProperties = async () => ({
+    workbook: fixture.workbook,
+    editState: { ...fixture.state.editState, undoDepth: 1, redoDepth: 0 },
+  });
+  await fixture.properties();
+  fixture.state.client.undoEdit = async () => ({
+    workbook: fixture.workbook,
+    editState: { ...fixture.state.editState, undoDepth: 0, redoDepth: 1 },
+  });
+  await fixture.controller.applyHistoryEdit("undo");
+  assert.equal(fixture.elements["error-banner"].hidden, false);
+  fixture.state.client.setCellAndRecalculate = async () => ({
+    workbook: fixture.workbook,
+    editState: { ...fixture.state.editState, undoDepth: 1, redoDepth: 0 },
+    recalculation: {
+      computedCells: 1,
+      unchangedCells: 0,
+      unsupportedCells: 0,
+      reasons: [],
+    },
+  });
+  await fixture.commit();
+  assert.equal(fixture.elements["error-banner"].hidden, true);
+  await fixture.controller.applyHistoryEdit("undo");
+  assert.equal(fixture.elements["error-banner"].hidden, false);
+  fixture.state.client.redoEdit = async () => ({
+    workbook: fixture.workbook,
+    editState: { ...fixture.state.editState, undoDepth: 1, redoDepth: 0 },
+  });
+  await fixture.controller.applyHistoryEdit("redo");
+  assert.equal(fixture.elements["error-banner"].hidden, true);
+});
+
+test("the refreshed renderer may clamp a retained page after cell, metadata, and history edits", async () => {
+  const pages = [];
+  const fixture = setup({
+    renderCurrent(state) {
+      pages.push(state.pageIndex);
+      state.pageIndex = Math.min(state.pageIndex, 1);
+    },
+  });
+  const result = () => ({
+    workbook: fixture.workbook,
+    editState: fixture.state.editState,
+  });
+  fixture.state.client.setCell = async () => result();
+  fixture.state.client.setDocumentProperties = async () => result();
+  fixture.state.client.undoEdit = async () => result();
+  await fixture.controller.commitCellEdit(
+    {
+      client: fixture.state.client,
+      documentId: fixture.state.documentId,
+      sheetIndex: 0,
+      row: 0,
+      col: 0,
+    },
+    { kind: "number", value: 1 },
+  );
+  assert.equal(fixture.state.pageIndex, 1);
+  fixture.state.pageIndex = 3;
+  await fixture.controller.openPropertiesEditor();
+  fixture.elements["properties-form"].emit("submit");
+  await flush();
+  assert.equal(fixture.state.pageIndex, 1);
+  fixture.state.pageIndex = 3;
+  await fixture.controller.applyHistoryEdit("undo");
+  assert.equal(fixture.state.pageIndex, 1);
+  assert.deepEqual(pages, [3, 3, 3]);
+});
+
+test("new document identity clears warning history without clearing unrelated errors", async () => {
+  for (const field of ["client", "documentId"]) {
+    const fixture = warningFixture();
+    await fixture.commit();
+    fixture.state[field] = field === "client" ? {} : "document-two";
+    fixture.controller.updateEditUi();
+    assert.equal(fixture.elements["error-banner"].hidden, true);
+    assert.equal(fixture.elements["error-message"].textContent, "");
+    assert.doesNotMatch(
+      fixture.elements["status-message"].textContent,
+      /unsupported formula/,
+    );
+  }
+  const fixture = warningFixture();
+  await fixture.commit();
+  fixture.elements["error-message"].textContent = "Current renderer error";
+  fixture.state.documentId = "document-two";
+  fixture.controller.updateEditUi();
+  assert.equal(fixture.elements["error-banner"].hidden, false);
+  assert.equal(
+    fixture.elements["error-message"].textContent,
+    "Current renderer error",
+  );
+});
+
+test("failed and stale metadata/history results cannot change current warnings or pages", async () => {
+  for (const operation of ["properties", "undo", "redo"]) {
+    for (const outcome of ["failed", "stale-result", "stale-error"]) {
+      const stale = outcome !== "failed";
+      const fixture = warningFixture();
+      await fixture.commit();
+      const warning = fixture.elements["error-message"].textContent;
+      const pending = deferred();
+      const method =
+        operation === "properties"
+          ? "setDocumentProperties"
+          : `${operation}Edit`;
+      fixture.state.client[method] = () => pending.promise;
+      const task =
+        operation === "properties"
+          ? fixture.properties()
+          : fixture.controller.applyHistoryEdit(operation);
+      await flush();
+      const currentWorkbook = {
+        ...fixture.workbook,
+        properties: { title: "Current" },
+      };
+      if (stale) {
+        fixture.state.documentId = "document-two";
+        fixture.state.workbook = currentWorkbook;
+        fixture.state.busy = false;
+        fixture.controller.updateEditUi();
+        fixture.elements["error-message"].textContent = "Current diagnostic";
+        fixture.elements["status-message"].textContent = "Current status";
+        fixture.elements["error-banner"].hidden = false;
+        fixture.state.pageIndex = 5;
+        if (outcome === "stale-error")
+          pending.reject(new Error("Old document error"));
+        else
+          pending.resolve({
+            workbook: fixture.workbook,
+            editState: fixture.state.editState,
+          });
+      } else {
+        pending.reject(new Error("Mutation rejected"));
+      }
+      await task;
+      await flush();
+      if (stale) {
+        assert.equal(fixture.state.workbook, currentWorkbook);
+        assert.equal(fixture.state.pageIndex, 5);
+        assert.equal(
+          fixture.elements["error-message"].textContent,
+          "Current diagnostic",
+        );
+        assert.equal(
+          fixture.elements["status-message"].textContent,
+          "Current status",
+        );
+        assert.equal(fixture.state.busy, false);
+        assert.deepEqual(fixture.calls.errors, []);
+      } else {
+        assert.equal(fixture.elements["error-message"].textContent, warning);
+        assert.equal(fixture.elements["error-banner"].hidden, false);
+      }
+    }
+  }
+});
+
+test("a stale metadata request releases form buttons for the next document", async () => {
+  const fixture = warningFixture();
+  const buttons = [control(), control()];
+  fixture.elements["properties-form"].querySelectorAll = () => buttons;
+  const pending = deferred();
+  fixture.state.client.setDocumentProperties = () => pending.promise;
+  await fixture.properties();
+  assert.ok(buttons.every((button) => button.disabled));
+  fixture.state.documentId = "document-two";
+  fixture.state.busy = false;
+  fixture.controller.closePropertiesEditor();
+  pending.resolve({
+    workbook: fixture.workbook,
+    editState: fixture.state.editState,
+  });
+  await flush();
+  assert.ok(buttons.every((button) => !button.disabled));
+  await fixture.controller.openPropertiesEditor();
+  assert.equal(fixture.elements["properties-dialog"].open, true);
 });
 
 test("a stale recalculation result cannot overwrite a new document or its visible diagnostic", async () => {

--- a/viewer/tests/grid-editor.test.mjs
+++ b/viewer/tests/grid-editor.test.mjs
@@ -33,6 +33,7 @@ function element() {
   const classes = new Set();
   const attrs = new Map();
   let value = "";
+  let disabled = false;
   return {
     get value() {
       return value;
@@ -41,7 +42,14 @@ function element() {
       value = String(next).replace(/\r\n?/g, "\n");
     },
     hidden: true,
-    disabled: false,
+    get disabled() {
+      return disabled;
+    },
+    set disabled(next) {
+      disabled = Boolean(next);
+      if (disabled && this.ownerDocument?.activeElement === this)
+        this.ownerDocument.activeElement = this.ownerDocument.body;
+    },
     style: {},
     dataset: {},
     parentElement: null,
@@ -80,7 +88,9 @@ function element() {
     },
     getAttribute: (name) => attrs.get(name),
     focus() {
+      if (this.disabled) return;
       this.focused = true;
+      if (this.ownerDocument) this.ownerDocument.activeElement = this;
     },
     setSelectionRange(start, end) {
       this.selectionStart = start;
@@ -89,8 +99,9 @@ function element() {
     getBoundingClientRect: () => ({ left: 100, top: 50 }),
   };
 }
-function setup({ readOnly = false, readCell, commitCellEdit } = {}) {
-  const calls = { reads: [], commits: [], selections: [], errors: [] };
+function setup({ readOnly = false, readCell, commitCellEdit, focusOutsideGrid } = {}) {
+  const calls = { reads: [], commits: [], selections: [], errors: [], exits: [] };
+  const exitTargets = { previous: element(), next: element() };
   const elements = Object.fromEntries(
     [
       "document-surface",
@@ -138,6 +149,12 @@ function setup({ readOnly = false, readCell, commitCellEdit } = {}) {
       },
     },
     onSelection: (value) => calls.selections.push(value),
+    focusOutsideGrid: (direction) => {
+      calls.exits.push(direction);
+      if (focusOutsideGrid) return focusOutsideGrid(direction);
+      exitTargets[direction].focus();
+      return true;
+    },
     showError: (error) => calls.errors.push(error),
   });
   grid.mount(interaction, svg);
@@ -147,6 +164,7 @@ function setup({ readOnly = false, readCell, commitCellEdit } = {}) {
     calls,
     elements,
     svg,
+    exitTargets,
     input: elements["grid-input"],
     outline: elements["grid-selection"],
     layer: elements["grid-layer"],
@@ -389,7 +407,7 @@ test("focused navigation reveals the cell while inspector synchronization never 
 });
 
 test("keyboard navigation skips hidden/covered cells and stays bounded to rendered anchors", async () => {
-  const { input, outline } = setup();
+  const { input, outline, calls } = setup();
   await input.fire("keydown", { key: "ArrowRight" });
   assert.equal(outline.dataset.reference, "C1");
   await input.fire("keydown", { key: "Tab" });
@@ -400,6 +418,178 @@ test("keyboard navigation skips hidden/covered cells and stays bounded to render
   assert.equal(outline.dataset.reference, "A1");
   await input.fire("keydown", { key: "ArrowLeft" });
   assert.equal(outline.dataset.reference, "A1");
+  assert.deepEqual(calls.exits, []);
+});
+
+test("Tab and Shift+Tab focus real outside targets at the last and first cell", async () => {
+  for (const [direction, row, col, shiftKey] of [
+    ["next", 2, 2, false],
+    ["previous", 0, 0, true],
+  ]) {
+    const { grid, input, calls, exitTargets } = setup();
+    await grid.select(row, col);
+    const event = await input.fire("keydown", { key: "Tab", shiftKey });
+    assert.equal(event.prevented, true);
+    assert.equal(event.stopped, true);
+    assert.deepEqual(calls.exits, [direction]);
+    assert.equal(exitTargets[direction].focused, true);
+    assert.deepEqual(calls.commits, []);
+    assert.equal(grid.hasDraft(), false);
+  }
+});
+
+test("edge Tab waits for its own async commit and remount before moving focus", async () => {
+  for (const [direction, row, col, shiftKey] of [
+    ["next", 2, 2, false],
+    ["previous", 0, 0, true],
+  ]) {
+    const pending = deferred();
+    const fixture = setup({
+      commitCellEdit: () => {
+        fixture.grid.mount(interaction, fixture.svg);
+        return pending.promise;
+      },
+    });
+    await fixture.grid.select(row, col);
+    await fixture.grid.beginEdit("77");
+    const event = await fixture.input.fire("keydown", { key: "Tab", shiftKey });
+    assert.equal(event.prevented, true, "default is cancelled before the async write");
+    assert.deepEqual(fixture.calls.exits, []);
+    assert.equal(fixture.grid.hasDraft(), true);
+    pending.resolve(true);
+    await flush();
+    assert.deepEqual(fixture.calls.exits, [direction]);
+    assert.equal(fixture.exitTargets[direction].focused, true);
+    assert.equal(fixture.grid.hasDraft(), false);
+    assert.equal(fixture.calls.commits.length, 1);
+  }
+});
+
+test("edge Tab preserves failed or stale drafts without moving focus", async () => {
+  for (const outcome of ["failed", "rejected", "stale"]) {
+    const pending = deferred();
+    const { grid, state, input, calls } = setup({
+      commitCellEdit: () => pending.promise,
+    });
+    await grid.select(2, 2);
+    await grid.beginEdit("77");
+    await input.fire("keydown", { key: "Tab" });
+    if (outcome === "failed") pending.reject(new Error("Save failed"));
+    else if (outcome === "rejected") pending.resolve(false);
+    else {
+      state.documentId = "another workbook";
+      pending.resolve(true);
+    }
+    await flush();
+    assert.deepEqual(calls.exits, [], outcome);
+    assert.equal(grid.hasDraft(), true, outcome);
+    assert.equal(input.value, "77", outcome);
+  }
+});
+
+test("failed keyboard commits restore the retained draft after disabling blurs the input", async () => {
+  for (const key of ["Tab", "Enter"]) {
+    for (const outcome of ["failed", "rejected"]) {
+      const pending = deferred();
+      const { grid, input, calls } = setup({ commitCellEdit: () => pending.promise });
+      const document = { activeElement: null, body: element() };
+      input.ownerDocument = document;
+      await grid.select(2, 2);
+      await grid.beginEdit("=UNKNOWNFUNCTION()");
+      assert.equal(document.activeElement, input);
+      await input.fire("keydown", { key });
+      assert.equal(input.disabled, true);
+      assert.equal(document.activeElement, document.body);
+      if (outcome === "failed") pending.reject(new Error("Unsupported formula"));
+      else pending.resolve(false);
+      await flush();
+      assert.equal(input.disabled, false);
+      assert.equal(document.activeElement, input, `${key}: ${outcome}`);
+      assert.equal(input.value, "=UNKNOWNFUNCTION()");
+      assert.equal(grid.hasDraft(), true);
+      assert.deepEqual(calls.exits, []);
+    }
+  }
+});
+
+test("failed commits never steal focus after a user focus move or workbook change", async () => {
+  for (const outcome of ["other-control", "stale", "toolbar"]) {
+    const pending = deferred();
+    const { grid, state, input } = setup({ commitCellEdit: () => pending.promise });
+    const document = { activeElement: null, body: element() };
+    input.ownerDocument = document;
+    await grid.select(2, 2);
+    await grid.beginEdit("77");
+    const otherControl = element();
+    if (outcome === "toolbar") document.activeElement = otherControl;
+    const committing = grid.commit();
+    if (outcome === "other-control") document.activeElement = otherControl;
+    if (outcome === "stale") state.documentId = "another workbook";
+    pending.resolve(false);
+    assert.equal(await committing, false);
+    assert.equal(document.activeElement, outcome === "stale" ? document.body : otherControl);
+    assert.equal(grid.hasDraft(), true);
+    assert.equal(input.value, "77");
+  }
+});
+
+test("edge Tab can exit when its committed blank removes the last rendered cell", async () => {
+  const fixture = setup({
+    commitCellEdit: async () => {
+      fixture.grid.mount({ ...interaction, cells: interaction.cells.slice(0, 1) }, fixture.svg);
+      return true;
+    },
+  });
+  await fixture.grid.select(2, 2);
+  await fixture.grid.beginEdit("");
+  await fixture.input.fire("keydown", { key: "Tab" });
+  assert.equal(fixture.grid.hasDraft(), false);
+  assert.deepEqual(fixture.calls.commits[0][1], { kind: "blank" });
+  assert.deepEqual(fixture.calls.exits, ["next"]);
+  assert.equal(fixture.exitTargets.next.focused, true);
+});
+
+test("edge Tab preserves selection when no outside target can accept focus", async () => {
+  const { grid, input, outline, calls, exitTargets } = setup({
+    focusOutsideGrid: () => false,
+  });
+  await grid.select(2, 2);
+  await input.fire("keydown", { key: "Tab" });
+  assert.deepEqual(calls.exits, ["next"]);
+  assert.equal(exitTargets.next.focused, undefined);
+  assert.equal(outline.dataset.reference, "C3");
+  assert.equal(grid.hasDraft(), false);
+  assert.deepEqual(calls.commits, []);
+});
+
+test("a successful edge commit does not steal focus from another control", async () => {
+  const pending = deferred();
+  const { grid, input, calls } = setup({ commitCellEdit: () => pending.promise });
+  const document = { activeElement: input, body: element() };
+  input.ownerDocument = document;
+  await grid.select(2, 2);
+  await grid.beginEdit("77");
+  await input.fire("keydown", { key: "Tab" });
+  const otherControl = element();
+  document.activeElement = otherControl;
+  pending.resolve(true);
+  await flush();
+  assert.equal(grid.hasDraft(), false);
+  assert.deepEqual(calls.exits, []);
+  assert.equal(document.activeElement, otherControl);
+});
+
+test("edge Tab leaves IME composition to the native input without committing", async () => {
+  const { grid, input, calls } = setup();
+  await grid.select(2, 2);
+  await input.fire("compositionstart");
+  input.value = "한글";
+  await input.fire("input");
+  const event = await input.fire("keydown", { key: "Tab", isComposing: true });
+  assert.equal(event.prevented, false);
+  assert.deepEqual(calls.exits, []);
+  assert.deepEqual(calls.commits, []);
+  assert.equal(grid.hasDraft(), true);
 });
 
 test("F2/Enter edit the selected source value; Escape and blur never write", async () => {


### PR DESCRIPTION
## Summary

- Preserve cached-formula warnings through metadata and undo/redo, keep the current print page, and ignore stale document results while releasing dialog controls.
- Let Tab/Shift+Tab leave worksheet boundaries after successful edits; preserve rejected drafts and keyboard focus, including real native textarea blur behavior.
- Separate read-only release verification from protected publication using immutable artifact ID/digest, exact run/repository/SHA, the unchanged 48/52-file inventories, and byte-identical Cargo repack checks.
- Derive crate paths from validated package versions in release, CI, and contributor commands.

## Verification

- Viewer: 98 unit tests and full pinned Chrome 150.0.7871.115 browser journey, including multipage edits, metadata, undo/redo, warning continuity, and successful/rejected grid-edge commits.
- VS Code: 4 unit tests; 1.134.0 and 1.96.0 trusted, untrusted, and virtual workspace journeys.
- Python: 873 tests; 24 added workflow-policy negative mutations and executable artifact authentication tests.
- Workflow policy, release identity, public hygiene, package verification, and diff checks pass.
- Independent review of UI/history/focus and publication handoff; all 23 release shell blocks parse.
- Production behavior regressions were reproduced before fixes. Local Node 26.7/npm 11.19 differ from hosted pinned Node 24.18/npm 11.16; exact-head hosted checks remain required.

No package versions or release tags are changed, and this PR does not publish a package.
