### PR TITLE
Add atomic range paste and read-only release handoff rehearsal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
         description: "Prior clean verification run ID to compare against"
         required: false
         type: string
+      rehearse_publication:
+        description: "Rehearse the exact verified publication handoff without publishing"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: read
@@ -41,6 +46,7 @@ jobs:
       contents: read
     outputs:
       version: ${{ steps.release.outputs.version }}
+      rehearse: ${{ steps.release.outputs.rehearse }}
       source_attempt: ${{ steps.release.outputs.source_attempt }}
       artifact_id: ${{ steps.publication_bundle.outputs.artifact-id }}
       artifact_digest: ${{ steps.publication_bundle.outputs.artifact-digest }}
@@ -51,9 +57,25 @@ jobs:
           persist-credentials: false
       - name: Validate release identity
         id: release
+        env:
+          REQUEST_REHEARSAL: ${{ github.event_name == 'workflow_dispatch' && toJSON(inputs.rehearse_publication) || 'false' }}
+          BASELINE_RUN_ID: ${{ inputs.baseline_run_id }}
         shell: bash
         run: |
           set -euo pipefail
+          case "$REQUEST_REHEARSAL" in
+            true|false) ;;
+            *) echo "rehearsal input must be a boolean" >&2; exit 1 ;;
+          esac
+          if [[ "$REQUEST_REHEARSAL" == "true" ]]; then
+            test "$GITHUB_EVENT_NAME" = "workflow_dispatch"
+            test "$GITHUB_REPOSITORY" = "HyunjoJung/rxls"
+            test "$GITHUB_REF" = "refs/heads/main"
+            test -z "$BASELINE_RUN_ID" || {
+              echo "rehearsal and baseline comparison are mutually exclusive" >&2
+              exit 1
+            }
+          fi
           version=$(python3 -c "import pathlib,tomllib; print(tomllib.loads(pathlib.Path('Cargo.toml').read_text(encoding='utf-8'))['package']['version'])")
           [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]] || {
             echo "Cargo.toml contains an invalid release version" >&2
@@ -81,6 +103,7 @@ jobs:
             echo "workflow_dispatch is verification-only; no publish will run"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "rehearse=$REQUEST_REHEARSAL" >> "$GITHUB_OUTPUT"
           echo "source_attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (2026-07-15)
         with:
@@ -594,7 +617,7 @@ jobs:
           if-no-files-found: error
 
       - name: Require successful exact-SHA CI and CodeQL runs
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || steps.release.outputs.rehearse == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -633,7 +656,7 @@ jobs:
           require_successful_push codeql.yml .github/workflows/codeql.yml CodeQL
 
       - name: Require exact-SHA two-candidate publication attestation
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || steps.release.outputs.rehearse == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -829,10 +852,10 @@ jobs:
           python3 scripts/compare_release_bundles.py \
             target/attested-candidate-release dist \
             --output target/publication-attestation/rxls-tag-release-comparison.json
-          echo "publication authorized by candidate runs $selected_baseline and $selected_run; tag bundle matches the attested candidate"
+          echo "candidate runs $selected_baseline and $selected_run verified; current bundle matches the attested candidate"
 
       - name: Bind publication provenance into release manifest
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || steps.release.outputs.rehearse == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -869,11 +892,75 @@ jobs:
 
       - name: Upload verified publication bundle
         id: publication_bundle
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || steps.release.outputs.rehearse == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rxls-${{ steps.release.outputs.version }}-publication-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: dist/*
+          if-no-files-found: error
+          retention-days: 30
+
+  rehearse:
+    name: Rehearse publication handoff (read-only)
+    needs: verify
+    if: github.repository == 'HyunjoJung/rxls' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && needs.verify.outputs.rehearse == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+    env:
+      ARTIFACT_ID: ${{ needs.verify.outputs.artifact_id }}
+      ARTIFACT_DIGEST: ${{ needs.verify.outputs.artifact_digest }}
+      SOURCE_ATTEMPT: ${{ needs.verify.outputs.source_attempt }}
+      VERIFIED_VERSION: ${{ needs.verify.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate rehearsal identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "HyunjoJung/rxls"
+          test "$GITHUB_EVENT_NAME" = "workflow_dispatch"
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git fetch origin main --no-tags
+          test "$(git rev-parse origin/main)" = "$GITHUB_SHA"
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (2026-07-15)
+        with:
+          toolchain: ${{ env.RELEASE_RUST_VERSION }}
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - name: Authenticate rehearsal artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]
+          mkdir -p target/publication
+          gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID" \
+            > target/publication/artifact.json
+          python3 scripts/core_release_handoff.py authenticate
+      - name: Download exact rehearsal bundle
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          artifact-ids: ${{ needs.verify.outputs.artifact_id }}
+          path: dist
+          merge-multiple: true
+          digest-mismatch: error
+      - name: Rehearse publication handoff and package bytes
+        run: python3 scripts/core_release_handoff.py verify
+      - name: Upload successful rehearsal receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: core-handoff-rehearsal-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: target/publication/handoff.json
           if-no-files-found: error
           retention-days: 30
 
@@ -887,6 +974,11 @@ jobs:
     permissions:
       actions: read
       contents: write
+    env:
+      ARTIFACT_ID: ${{ needs.verify.outputs.artifact_id }}
+      ARTIFACT_DIGEST: ${{ needs.verify.outputs.artifact_digest }}
+      SOURCE_ATTEMPT: ${{ needs.verify.outputs.source_attempt }}
+      VERIFIED_VERSION: ${{ needs.verify.outputs.version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -925,10 +1017,6 @@ jobs:
       - name: Authenticate verified publication artifact
         env:
           GH_TOKEN: ${{ github.token }}
-          ARTIFACT_ID: ${{ needs.verify.outputs.artifact_id }}
-          ARTIFACT_DIGEST: ${{ needs.verify.outputs.artifact_digest }}
-          SOURCE_ATTEMPT: ${{ needs.verify.outputs.source_attempt }}
-          VERIFIED_VERSION: ${{ needs.verify.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
@@ -936,43 +1024,7 @@ jobs:
           mkdir -p target/publication
           gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID" \
             > target/publication/artifact.json
-          python3 - <<'PY'
-          import json
-          import os
-          import re
-          from pathlib import Path
-
-          artifact = json.loads(Path("target/publication/artifact.json").read_text())
-          expected_digest = os.environ["ARTIFACT_DIGEST"].removeprefix("sha256:")
-          attempt = os.environ["SOURCE_ATTEMPT"]
-          if not re.fullmatch(r"[0-9a-f]{64}", expected_digest):
-              raise SystemExit("invalid verified artifact digest")
-          if not re.fullmatch(r"[1-9][0-9]*", attempt) or int(attempt) > int(os.environ["GITHUB_RUN_ATTEMPT"]):
-              raise SystemExit("invalid verified source attempt")
-          expected_name = (
-              f"rxls-{os.environ['VERIFIED_VERSION']}-publication-"
-              f"{os.environ['GITHUB_SHA']}-{os.environ['GITHUB_RUN_ID']}-{attempt}"
-          )
-          if not isinstance(artifact, dict):
-              raise SystemExit("invalid publication artifact metadata")
-          expected = {
-              "id": int(os.environ["ARTIFACT_ID"]),
-              "name": expected_name,
-              "digest": f"sha256:{expected_digest}",
-              "expired": False,
-          }
-          if any(type(artifact.get(key)) is not type(value) or artifact[key] != value for key, value in expected.items()):
-              raise SystemExit("publication artifact identity differs from verified output")
-          run = artifact.get("workflow_run")
-          expected_run = {
-              "id": int(os.environ["GITHUB_RUN_ID"]),
-              "head_sha": os.environ["GITHUB_SHA"],
-              "repository_id": int(os.environ["GITHUB_REPOSITORY_ID"]),
-              "head_repository_id": int(os.environ["GITHUB_REPOSITORY_ID"]),
-          }
-          if not isinstance(run, dict) or any(type(run.get(key)) is not type(value) or run[key] != value for key, value in expected_run.items()):
-              raise SystemExit("publication artifact source differs from this verified run")
-          PY
+          python3 scripts/core_release_handoff.py authenticate
       - name: Download exact verified publication bundle
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
@@ -981,26 +1033,7 @@ jobs:
           merge-multiple: true
           digest-mismatch: error
       - name: Verify publication handoff and package bytes
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="${{ steps.release.outputs.version }}"
-          python3 scripts/check_workflow_policy.py
-          python3 scripts/check_release_identity.py
-          python3 scripts/check_cargo_publish_dry_run.py verify \
-            --manifest Cargo.toml \
-            --git-sha "$GITHUB_SHA" \
-            --receipt dist/release-cargo-publish-dry-run.json
-          python3 scripts/release_manifest.py \
-            --verify-bundle dist \
-            --expected-files 52 \
-            --version "$version" \
-            --git-rev "$GITHUB_SHA"
-          python3 scripts/check_core_package.py "dist/rxls-${version}.crate"
-          # Cargo has no stable publish-existing-archive command. Repacking the
-          # exact clean source must reproduce the verified archive byte for byte.
-          cargo package --locked
-          cmp "target/package/rxls-${version}.crate" "dist/rxls-${version}.crate"
+        run: python3 scripts/core_release_handoff.py verify
       - name: Install published WASM browser smoke runtime
         shell: bash
         run: |

--- a/bindings/render-wasm/README.md
+++ b/bindings/render-wasm/README.md
@@ -46,10 +46,11 @@ OOXML packages that cannot retain metadata report a stable read-only reason.
 Undo/redo history is bounded to 20 entries and 32 MiB, and every candidate is
 serialized and reopened before it replaces the live session.
 
-The current source build additionally exposes `renderSheetInteractive()` and
-`setCellAndRecalculate()`; these additions are not in the published 0.2.0 package.
-The former returns bounded, text-free cell rectangles from the same layout pass
-as the SVG. The latter applies a cell edit and refreshes supported formula
+The current source build additionally exposes `renderSheetInteractive()`,
+`setCellAndRecalculate()`, and `setRangeAndRecalculate()`; these additions are not
+in the published 0.2.0 package. Interactive rendering returns bounded, text-free
+cell rectangles from the same layout pass as the SVG. Recalculating edits apply
+a cell or rectangular range and refresh supported formula
 caches as one atomic, undoable change. Its `recalculation` summary reports
 computed and unsupported formula counts plus typed reason codes; unchanged
 caches are counted within the computed total and reported separately.
@@ -57,6 +58,25 @@ Unsupported formulas retain their old caches; a resource-limit or cache-write
 failure rejects the whole edit. Cache refresh preserves existing formula XML
 and unrelated package parts. Use ordinary `setCell()` when automatic cache
 refresh is not wanted.
+
+```js
+await client.setRangeAndRecalculate(opened.documentId, 0, 0, 0, [[
+  { kind: "number", value: 7 },
+  { kind: "formula-auto", formula: "A1*3" }
+]]);
+```
+
+Range coordinates are zero-based. The nonempty rectangular matrix is limited
+to 10,000 cells, 1 MiB of serialized request JSON, and 128 KiB of serialized
+JSON per cell; existing text, worksheet, and evaluator limits also apply.
+Automatic formulas are evaluated against the complete proposed range, so the
+example caches `21`. A newly pasted unsupported formula or a covered merged-cell
+target rejects the whole range. Formula text is used as supplied, without
+relative-reference translation. One undo restores the entire paste; save and
+reopen preserve the resulting formula caches and untouched package parts.
+Build and serve the client, worker, and WASM from the same source revision to
+use these methods; mixing the new client with an older WASM adapter rejects
+range editing with `wasm_api_mismatch`.
 
 `saveDocument()` returns `application/octet-stream` because the worker receives
 bytes without a trusted source filename; the host must retain the known

--- a/bindings/render-wasm/examples/editing_benchmark.rs
+++ b/bindings/render-wasm/examples/editing_benchmark.rs
@@ -1,0 +1,71 @@
+//! Repeatable native timings for a bounded large-workbook editing workload.
+
+use std::time::Instant;
+
+use rxls::Workbook;
+use rxls_render_wasm::RenderSession;
+use serde_json::json;
+
+fn main() {
+    let mut workbook = Workbook::new();
+    let sheet = workbook.add_sheet("Data");
+    for row in 0..2_000_u32 {
+        for col in 0..32_u16 {
+            sheet.write(row, col, f64::from(row * 32 + u32::from(col)));
+        }
+    }
+    for row in 0..200_u32 {
+        sheet.write_formula(row, 32, format!("A{}+B{}", row + 1, row + 1), 0.0);
+    }
+    let bytes = workbook.to_xlsx_checked().unwrap();
+    let mut samples = Vec::new();
+    let mut batch_samples = Vec::new();
+    let mut tall_samples = Vec::new();
+    let mut wide_samples = Vec::new();
+    for _ in 0..3 {
+        let mut session = RenderSession::new(&bytes, &[]).unwrap();
+        let started = Instant::now();
+        for col in 0..8_u16 {
+            session
+                .set_cell_recalculate_json(
+                    &json!({"sheetIndex":0,"row":0,"col":col,"value":{"kind":"number","value":99}})
+                        .to_string(),
+                )
+                .unwrap();
+        }
+        samples.push(started.elapsed().as_secs_f64());
+        let reopened = Workbook::open(&session.save_document_bytes().unwrap()).unwrap();
+        assert_eq!(
+            reopened.sheets[0].cell(0, 7),
+            Some(&rxls::Cell::Number(99.0))
+        );
+        let mut batch = RenderSession::new(&bytes, &[]).unwrap();
+        let request = json!({"sheetIndex":0,"startRow":0,"startCol":0,"values":[vec![json!({"kind":"number","value":99});8]]}).to_string();
+        let started = Instant::now();
+        batch.set_range_recalculate_json(&request).unwrap();
+        batch_samples.push(started.elapsed().as_secs_f64());
+        assert_eq!(
+            batch.save_document_bytes().unwrap(),
+            session.save_document_bytes().unwrap()
+        );
+        for (rows, cols, samples) in [
+            (10_000, 1, &mut tall_samples),
+            (1, 10_000, &mut wide_samples),
+        ] {
+            let mut batch = RenderSession::new(&bytes, &[]).unwrap();
+            let request = json!({"sheetIndex":0,"startRow":0,"startCol":0,"values":vec![vec![json!({"kind":"number","value":99});cols];rows]}).to_string();
+            let started = Instant::now();
+            batch.set_range_recalculate_json(&request).unwrap();
+            samples.push(started.elapsed().as_secs_f64());
+            let reopened = Workbook::open(&batch.save_document_bytes().unwrap()).unwrap();
+            assert_eq!(
+                reopened.sheets[0].cell(rows as u32 - 1, cols as u16 - 1),
+                Some(&rxls::Cell::Number(99.0))
+            );
+        }
+    }
+    println!(
+        "{}",
+        json!({"schema":"rxls.editing-benchmark.v1","rows":2000,"columns":33,"formulaCells":200,"edits":8,"inputBytes":bytes.len(),"singleSeconds":samples,"batchSeconds":batch_samples,"tall10000Seconds":tall_samples,"wide10000Seconds":wide_samples})
+    );
+}

--- a/bindings/render-wasm/js/client.d.mts
+++ b/bindings/render-wasm/js/client.d.mts
@@ -172,6 +172,14 @@ export declare class RenderWorkerClient {
     value: EditableCell,
     options?: RenderRequestOptions,
   ): RenderRequest<RecalculatedEditResult>;
+  setRangeAndRecalculate(
+    documentId: string,
+    sheetIndex: number,
+    startRow: number,
+    startCol: number,
+    values: readonly (readonly EditableCell[])[],
+    options?: RenderRequestOptions,
+  ): RenderRequest<RecalculatedEditResult>;
   setDocumentProperties(
     documentId: string,
     properties: DocumentPropertiesInspection,

--- a/bindings/render-wasm/js/client.mjs
+++ b/bindings/render-wasm/js/client.mjs
@@ -29,6 +29,7 @@ const NON_CANCELLABLE_DISPATCHED_OPERATIONS = new Set([
   "close",
   "set-cell",
   "set-cell-recalculate",
+  "set-range-recalculate",
   "set-document-properties",
   "undo-edit",
   "redo-edit"
@@ -125,6 +126,10 @@ export class RenderWorkerClient {
 
   setCellAndRecalculate(documentId, sheetIndex, row, col, value, options = {}) {
     return this.request("set-cell-recalculate", { documentId, sheetIndex, row, col, value }, options);
+  }
+
+  setRangeAndRecalculate(documentId, sheetIndex, startRow, startCol, values, options = {}) {
+    return this.request("set-range-recalculate", { documentId, sheetIndex, startRow, startCol, values }, options);
   }
 
   setDocumentProperties(documentId, properties, options = {}) {
@@ -568,6 +573,7 @@ function responseIdentityFor(operation, payload) {
     case "close":
     case "edit-status":
     case "set-document-properties":
+    case "set-range-recalculate":
     case "undo-edit":
     case "redo-edit":
     case "save-document":
@@ -886,6 +892,7 @@ function validateOperationResult(operation, payload, result, capabilityLimits) {
       validateEditState(result.editState);
       return;
     case "set-cell-recalculate":
+    case "set-range-recalculate":
       assertPlainRecord(result, "recalculating edit result");
       assertExactKeys(result, ["documentId", "workbook", "editState", "recalculation"], "recalculating edit result");
       assertIdentity(result.documentId, payload.documentId, "documentId");

--- a/bindings/render-wasm/js/protocol.d.mts
+++ b/bindings/render-wasm/js/protocol.d.mts
@@ -8,6 +8,8 @@ export declare const MAX_OPEN_DOCUMENTS: 4;
 export declare const MAX_OPEN_RESOURCE_BYTES: 134217728;
 export declare const MAX_OPTIONS_BYTES: 65536;
 export declare const MAX_EDIT_REQUEST_BYTES: 131072;
+export declare const MAX_RANGE_EDIT_REQUEST_BYTES: 1048576;
+export declare const MAX_RANGE_EDIT_CELLS: 10000;
 export declare const MAX_EDIT_HISTORY_ENTRIES: 20;
 export declare const MAX_EDIT_HISTORY_BYTES: 33554432;
 export declare const MAX_PENDING_REQUESTS: 32;
@@ -474,6 +476,7 @@ export type RenderOperation =
   | "read-cell"
   | "set-cell"
   | "set-cell-recalculate"
+  | "set-range-recalculate"
   | "set-document-properties"
   | "undo-edit"
   | "redo-edit"
@@ -502,6 +505,13 @@ export interface RenderOperationPayloads {
     readonly value: EditableCell;
   };
   readonly "set-cell-recalculate": RenderOperationPayloads["set-cell"];
+  readonly "set-range-recalculate": {
+    readonly documentId: string;
+    readonly sheetIndex: number;
+    readonly startRow: number;
+    readonly startCol: number;
+    readonly values: readonly (readonly EditableCell[])[];
+  };
   readonly "set-document-properties": {
     readonly documentId: string;
     readonly properties: DocumentPropertiesInspection;
@@ -553,6 +563,7 @@ export interface RenderOperationResults {
   readonly "read-cell": ReadCellResult;
   readonly "set-cell": EditMutationResult;
   readonly "set-cell-recalculate": RecalculatedEditResult;
+  readonly "set-range-recalculate": RecalculatedEditResult;
   readonly "set-document-properties": EditMutationResult;
   readonly "undo-edit": EditMutationResult;
   readonly "redo-edit": EditMutationResult;

--- a/bindings/render-wasm/js/protocol.mjs
+++ b/bindings/render-wasm/js/protocol.mjs
@@ -8,6 +8,8 @@ export const MAX_OPEN_DOCUMENTS = 4;
 export const MAX_OPEN_RESOURCE_BYTES = 128 * 1024 * 1024;
 export const MAX_OPTIONS_BYTES = 64 * 1024;
 export const MAX_EDIT_REQUEST_BYTES = 128 * 1024;
+export const MAX_RANGE_EDIT_REQUEST_BYTES = 1024 * 1024;
+export const MAX_RANGE_EDIT_CELLS = 10_000;
 export const MAX_EDIT_HISTORY_ENTRIES = 20;
 export const MAX_EDIT_HISTORY_BYTES = MAX_INPUT_BYTES;
 export const MAX_PENDING_REQUESTS = 32;
@@ -54,6 +56,7 @@ const OPERATIONS = new Set([
   "read-cell",
   "set-cell",
   "set-cell-recalculate",
+  "set-range-recalculate",
   "set-document-properties",
   "undo-edit",
   "redo-edit",
@@ -225,6 +228,14 @@ export function preflightRequest({ operation, payload }) {
         value: payload.value
       }).byteLength;
     }
+    case "set-range-recalculate": {
+      rangeCellData(payload, "payload");
+      assertExactKeys(payload, ["documentId", "sheetIndex", "startRow", "startCol", "values"], "payload");
+      validateDocumentId(payload.documentId);
+      boundedIndex(payload.sheetIndex, "payload.sheetIndex", MAX_SHEETS, "sheets");
+      validateCellCoordinate(payload.startRow, payload.startCol);
+      return rangeEditBytes(payload);
+    }
     case "set-document-properties": {
       assertExactKeys(payload, ["documentId", "properties"], "payload");
       validateDocumentId(payload.documentId);
@@ -340,6 +351,79 @@ export function editJson(value) {
     );
   }
   return encoded;
+}
+
+// Count each bounded cell before cloning or serializing the complete matrix.
+function rangeEditBytes({ sheetIndex, startRow, startCol, values }) {
+  const location = "payload.values";
+  if (!Array.isArray(values) || values.length === 0 || values.length > MAX_RANGE_EDIT_CELLS) {
+    throw new RenderProtocolError("invalid_edit", "values must be a nonempty bounded matrix", location);
+  }
+  rangeArray(values, values.length, location);
+  if (!Array.isArray(values[0])) {
+    throw new RenderProtocolError("invalid_edit", "each range row must be an array", location);
+  }
+  const width = values[0].length;
+  if (!Number.isSafeInteger(width) || width <= 0 || width * values.length > MAX_RANGE_EDIT_CELLS) {
+    throw new RenderProtocolError("invalid_edit", "range must contain at most 10000 cells", location);
+  }
+  validateCellCoordinate(startRow + values.length - 1, startCol + width - 1);
+  let bytes = JSON.stringify({ sheetIndex, startRow, startCol, values: [] }).length;
+  const add = (count) => {
+    bytes += count;
+    if (bytes > MAX_RANGE_EDIT_REQUEST_BYTES) {
+      throw limitError("editRequestBytes", MAX_RANGE_EDIT_REQUEST_BYTES, bytes, location);
+    }
+  };
+  for (let row = 0; row < values.length; row += 1) {
+    rangeArray(values[row], width, `${location}[${row}]`);
+    add(2 + (row === 0 ? 0 : 1));
+    for (let col = 0; col < width; col += 1) {
+      const cell = values[row][col];
+      const cellLocation = `${location}[${row}][${col}]`;
+      rangeCellData(cell, cellLocation);
+      validateEditableCell(cell, cellLocation, true);
+      // Per-cell strings remain capped by the original 128KiB input contract.
+      const cellBytes = new TextEncoder().encode(JSON.stringify(cell)).byteLength;
+      if (cellBytes > MAX_EDIT_REQUEST_BYTES) {
+        throw limitError("editRequestBytes", MAX_EDIT_REQUEST_BYTES, cellBytes, cellLocation);
+      }
+      add(cellBytes + (col === 0 ? 0 : 1));
+    }
+  }
+  return bytes;
+}
+
+function rangeArray(value, length, location) {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype || value.length !== length || Reflect.ownKeys(value).length !== length + 1) {
+    throw new RenderProtocolError("invalid_edit", "range rows must be dense and rectangular", location);
+  }
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor?.enumerable || !("value" in descriptor)) {
+      throw new RenderProtocolError("invalid_edit", "range entries must be own data values", location);
+    }
+  }
+}
+
+function rangeCellData(value, location) {
+  assertPlainObject(value, location);
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (typeof key !== "string" || !descriptor.enumerable || !("value" in descriptor)) {
+      throw new RenderProtocolError("invalid_edit", "cell fields must be own data values", location);
+    }
+  }
+  // Formula caches contain scalars, so inspect at most this one extra level.
+  if (value.kind === "formula") {
+    assertPlainObject(value.cached, `${location}.cached`);
+    for (const key of Reflect.ownKeys(value.cached)) {
+      const descriptor = Object.getOwnPropertyDescriptor(value.cached, key);
+      if (typeof key !== "string" || !descriptor.enumerable || !("value" in descriptor)) {
+        throw new RenderProtocolError("invalid_edit", "cached fields must be own data values", location);
+      }
+    }
+  }
 }
 
 export function boundedIndex(value, location, countLimit, resource) {
@@ -830,6 +914,9 @@ function validateEditString(value, location) {
       `${location} must be a string`,
       location
     );
+  }
+  if (value.length > MAX_EDIT_REQUEST_BYTES) {
+    throw limitError("editRequestBytes", MAX_EDIT_REQUEST_BYTES, value.length, location);
   }
   const bytes = new TextEncoder().encode(value).byteLength;
   if (bytes > MAX_EDIT_REQUEST_BYTES) {

--- a/bindings/render-wasm/js/worker-runtime.d.mts
+++ b/bindings/render-wasm/js/worker-runtime.d.mts
@@ -15,6 +15,7 @@ export interface RenderWasmSession {
   ): RenderMaybePromise<string>;
   setCellJson(requestJson: string): RenderMaybePromise<string>;
   setCellRecalculateJson?(requestJson: string): RenderMaybePromise<string>;
+  setRangeRecalculateJson?(requestJson: string): RenderMaybePromise<string>;
   setDocumentPropertiesJson(requestJson: string): RenderMaybePromise<string>;
   undoEditJson(): RenderMaybePromise<string>;
   redoEditJson(): RenderMaybePromise<string>;

--- a/bindings/render-wasm/js/worker-runtime.mjs
+++ b/bindings/render-wasm/js/worker-runtime.mjs
@@ -38,6 +38,7 @@ const NON_CANCELLABLE_ACTIVE_OPERATIONS = new Set([
   "close",
   "set-cell",
   "set-cell-recalculate",
+  "set-range-recalculate",
   "set-document-properties",
   "undo-edit",
   "redo-edit"
@@ -301,6 +302,8 @@ export class RenderWorkerRuntime {
         return this.#setCell(payload);
       case "set-cell-recalculate":
         return this.#setCell(payload, true);
+      case "set-range-recalculate":
+        return this.#setRange(payload);
       case "set-document-properties":
         return this.#setDocumentProperties(payload);
       case "undo-edit":
@@ -606,6 +609,18 @@ export class RenderWorkerRuntime {
     const { documentId, session } = this.#document(payload);
     const result = await session.setDocumentPropertiesJson(JSON.stringify(payload.properties));
     return { documentId, ...this.#mutationResult(result) };
+  }
+
+  async #setRange(payload) {
+    const { documentId, session } = this.#document(payload);
+    if (typeof session.setRangeRecalculateJson !== "function") {
+      throw new RenderProtocolError("wasm_api_mismatch", "WASM does not support recalculating range edits", "wasm");
+    }
+    const result = await session.setRangeRecalculateJson(JSON.stringify({
+      sheetIndex: payload.sheetIndex, startRow: payload.startRow,
+      startCol: payload.startCol, values: payload.values
+    }));
+    return { documentId, ...this.#mutationResult(result, true) };
   }
 
   async #historyEdit(payload, direction) {
@@ -1315,6 +1330,7 @@ function operationStage(operation) {
       return "inspecting";
     case "set-cell":
     case "set-cell-recalculate":
+    case "set-range-recalculate":
     case "set-document-properties":
     case "undo-edit":
     case "redo-edit":

--- a/bindings/render-wasm/src/lib.rs
+++ b/bindings/render-wasm/src/lib.rs
@@ -8,6 +8,7 @@
 #![deny(missing_docs)]
 
 mod interaction;
+mod range_edit;
 mod recalculation;
 
 use rxls::{Cell, DocProperties, EditCapability, EditReadOnlyReason, Spreadsheet, Workbook};
@@ -327,7 +328,7 @@ impl From<DocumentPropertiesEditRequest> for DocProperties {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "kind", deny_unknown_fields, rename_all = "kebab-case")]
 enum EditableCell {
     Blank,
@@ -361,7 +362,7 @@ enum ResolvedCellEdit {
     Formula { formula: String, cached: Cell },
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "kind", deny_unknown_fields, rename_all = "kebab-case")]
 enum EditableCachedCell {
     Text { value: String },
@@ -559,6 +560,13 @@ impl RenderSession {
     #[wasm_bindgen(js_name = setCellRecalculateJson)]
     pub fn set_cell_recalculate_json(&mut self, request_json: &str) -> Result<String, JsValue> {
         self.set_cell_recalculate_json_core(request_json)
+            .map_err(js_error)
+    }
+
+    /// Atomically replace one bounded rectangle, refresh formula caches, and add one undo entry.
+    #[wasm_bindgen(js_name = setRangeRecalculateJson)]
+    pub fn set_range_recalculate_json(&mut self, request_json: &str) -> Result<String, JsValue> {
+        self.set_range_recalculate_json_core(request_json)
             .map_err(js_error)
     }
 
@@ -1099,6 +1107,15 @@ impl RenderSession {
         edit: impl FnOnce(&mut Spreadsheet) -> rxls::Result<()>,
         recalculate: bool,
     ) -> Result<String, FacadeError> {
+        self.apply_edit_checked(edit, recalculate, &std::collections::BTreeSet::new())
+    }
+
+    fn apply_edit_checked(
+        &mut self,
+        edit: impl FnOnce(&mut Spreadsheet) -> rxls::Result<()>,
+        recalculate: bool,
+        required_formulas: &std::collections::BTreeSet<(usize, u32, u16)>,
+    ) -> Result<String, FacadeError> {
         ensure_editable(&self.spreadsheet)?;
         let previous = self.snapshot()?;
         let mut candidate = self.spreadsheet.clone();
@@ -1109,7 +1126,7 @@ impl RenderSession {
         validate_session_workbook(&workbook)?;
 
         let recalculation = if recalculate {
-            let summary = recalculation::apply(&mut candidate, &workbook)?;
+            let summary = recalculation::apply(&mut candidate, &workbook, required_formulas)?;
             if summary.changed_cells() > 0 {
                 let bytes = candidate.save().map_err(map_edit_error)?;
                 check_saved_workbook(&bytes)?;

--- a/bindings/render-wasm/src/range_edit.rs
+++ b/bindings/render-wasm/src/range_edit.rs
@@ -1,0 +1,346 @@
+//! Bounded rectangular edits share the single-edit atomic commit boundary.
+
+use super::*;
+
+const MAX_RANGE_EDIT_CELLS: usize = 10_000;
+const MAX_RANGE_EDIT_REQUEST_BYTES: usize = 1 << 20;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct Request {
+    sheet_index: usize,
+    start_row: u32,
+    start_col: u16,
+    values: Vec<Vec<EditableCell>>,
+}
+
+impl RenderSession {
+    pub(super) fn set_range_recalculate_json_core(
+        &mut self,
+        text: &str,
+    ) -> Result<String, FacadeError> {
+        ensure_editable(&self.spreadsheet)?;
+        if text.len() > MAX_RANGE_EDIT_REQUEST_BYTES {
+            return Err(FacadeError::limit(
+                "rangeEditRequestBytes",
+                MAX_RANGE_EDIT_REQUEST_BYTES as u64,
+                text.len() as u64,
+            ));
+        }
+        let request: Request =
+            serde_json::from_str(text).map_err(|_| invalid("invalid rectangular edit request"))?;
+        let columns = request.values.first().map_or(0, Vec::len);
+        let count = request.values.len().saturating_mul(columns);
+        if count > MAX_RANGE_EDIT_CELLS {
+            return Err(FacadeError::limit(
+                "rangeEditCells",
+                MAX_RANGE_EDIT_CELLS as u64,
+                count as u64,
+            ));
+        }
+        if columns == 0 || request.values.iter().any(|row| row.len() != columns) {
+            return Err(invalid("cell range must be nonempty and rectangular"));
+        }
+        let last_row = u64::from(request.start_row) + request.values.len() as u64 - 1;
+        let last_col = u64::from(request.start_col) + columns as u64 - 1;
+        if last_row > 1_048_575 || last_col > 16_383 {
+            return Err(invalid("cell range is outside the Excel grid"));
+        }
+        let sheet = self
+            .workbook
+            .sheets
+            .get(request.sheet_index)
+            .ok_or_else(|| invalid("sheet index is out of range"))?;
+        for &(r0, c0, r1, c1) in sheet.merged_ranges() {
+            let top = r0.max(request.start_row);
+            let left = c0.max(request.start_col);
+            let bottom = r1.min(last_row as u32);
+            let right = c1.min(last_col as u16);
+            if top <= bottom
+                && left <= right
+                && (top != r0 || left != c0 || bottom != r0 || right != c0)
+            {
+                return Err(invalid("cell range includes a merged-cell interior"));
+            }
+        }
+        let name = sheet.name.clone();
+        let mut required = std::collections::BTreeSet::new();
+        let mut values = Vec::with_capacity(request.values.len());
+        for (row_offset, row) in request.values.into_iter().enumerate() {
+            let mut output = Vec::with_capacity(columns);
+            for (col_offset, value) in row.into_iter().enumerate() {
+                let cell_bytes = serde_json::to_string(&value)
+                    .map_err(|_| invalid("invalid cell value"))?
+                    .len();
+                if cell_bytes > 128 * 1024 {
+                    return Err(FacadeError::limit(
+                        "editCellBytes",
+                        128 * 1024,
+                        cell_bytes as u64,
+                    ));
+                }
+                let cell = match value {
+                    EditableCell::Blank => None,
+                    EditableCell::Text { value } => Some(Cell::Text(value)),
+                    EditableCell::Number { value } => Some(Cell::Number(value)),
+                    EditableCell::Date { value } => Some(Cell::Date(value)),
+                    EditableCell::Boolean { value } => Some(Cell::Bool(value)),
+                    EditableCell::Error { value } => Some(Cell::Error(value)),
+                    EditableCell::Formula { formula, cached } => {
+                        Some(formula_cell(formula, cached.into_cell())?)
+                    }
+                    EditableCell::FormulaAuto { formula } => {
+                        required.insert((
+                            request.sheet_index,
+                            request.start_row + row_offset as u32,
+                            request.start_col + col_offset as u16,
+                        ));
+                        // This placeholder is never committed: the shared evaluator must
+                        // compute every requested automatic formula before the swap.
+                        Some(formula_cell(formula, Cell::Error("#N/A".into()))?)
+                    }
+                };
+                output.push(cell);
+            }
+            values.push(output);
+        }
+        self.apply_edit_checked(
+            move |candidate| {
+                candidate.set_cell_range_values(
+                    &name,
+                    request.start_row,
+                    request.start_col,
+                    &values,
+                )
+            },
+            true,
+            &required,
+        )
+    }
+}
+
+fn formula_cell(formula: String, cached: Cell) -> Result<Cell, FacadeError> {
+    let body = formula.trim().trim_start_matches('=').trim();
+    if body.is_empty() {
+        return Err(invalid("formula cannot be empty"));
+    }
+    Ok(Cell::Formula {
+        formula: body.into(),
+        cached: Box::new(cached),
+    })
+}
+
+fn invalid(message: &str) -> FacadeError {
+    FacadeError::simple("invalid_edit", message, "edit.range")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn session() -> RenderSession {
+        let mut workbook = Workbook::new();
+        workbook.add_sheet("Data").write(0, 0, 1.0);
+        workbook
+            .add_sheet("Total")
+            .write_formula(0, 0, "Data!A1+Data!B1", 1.0);
+        RenderSession::new_core(&workbook.to_xlsx_checked().unwrap(), &[]).unwrap()
+    }
+
+    #[test]
+    fn rectangular_paste_recalculates_post_paste_formulas_once_and_undoes_together() {
+        let mut session = session();
+        let before = session.save_document_bytes_core().unwrap();
+        let result: serde_json::Value = serde_json::from_str(
+            &session
+                .set_range_recalculate_json_core(
+                    &json!({"sheetIndex":0,"startRow":0,"startCol":0,"values":[
+                        [{"kind":"number","value":4},{"kind":"formula-auto","formula":"=A1*2"}],
+                        [{"kind":"text","value":"hello"},{"kind":"boolean","value":true}]
+                    ]})
+                    .to_string(),
+                )
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(result["editState"]["undoDepth"], 1);
+        assert_eq!(result["recalculation"]["computedCells"], 2);
+        assert_eq!(
+            session.workbook.sheets[1].cell(0, 0).unwrap().as_f64(),
+            Some(12.0)
+        );
+        let saved = session.save_document_bytes_core().unwrap();
+        let reopened = Workbook::open(&saved).unwrap();
+        assert_eq!(reopened.sheets[0].cell(0, 1).unwrap().as_f64(), Some(8.0));
+        session.undo_edit_core().unwrap();
+        assert_eq!(session.save_document_bytes_core().unwrap(), before);
+        session.redo_edit_core().unwrap();
+        assert_eq!(session.save_document_bytes_core().unwrap(), saved);
+    }
+
+    #[test]
+    fn rectangular_paste_fails_atomically_and_preserves_redo() {
+        let mut session = session();
+        session
+            .set_cell_json_core(
+                r#"{"sheetIndex":0,"row":0,"col":0,"value":{"kind":"number","value":2}}"#,
+            )
+            .unwrap();
+        session.undo_edit_core().unwrap();
+        let before = session.save_document_bytes_core().unwrap();
+        let history = session.edit_state_json();
+        for values in [
+            json!([]),
+            json!([[]]),
+            json!([[{"kind":"blank"}],[]]),
+            json!([[{"kind":"number","value":4},{"kind":"formula-auto","formula":"=UNKNOWNFUNCTION()"}]]),
+            json!([[{"kind":"formula-auto","formula":"=B1"},{"kind":"formula-auto","formula":"=A1"}]]),
+            json!([[{"kind":"formula-auto","formula":"="}]]),
+            json!([[{"kind":"text","value":"bad\u{0}xml"}]]),
+            json!([[{"kind":"formula","formula":"x".repeat(128*1024),"cached":{"kind":"number","value":0}}]]),
+            json!([[{"kind":"text","value":"x".repeat(32768)}]]),
+        ] {
+            let request = json!({"sheetIndex":0,"startRow":0,"startCol":0,"values":values});
+            assert!(session
+                .set_range_recalculate_json_core(&request.to_string())
+                .is_err());
+            assert_eq!(session.save_document_bytes_core().unwrap(), before);
+            assert_eq!(session.edit_state_json(), history);
+        }
+    }
+
+    #[test]
+    fn rectangular_paste_limits_ranges_and_request_bytes_before_mutation() {
+        let mut session = session();
+        let before = session.save_document_bytes_core().unwrap();
+        for request in [
+            json!({"sheetIndex":0,"startRow":1048575,"startCol":0,"values":[[{"kind":"blank"}],[{"kind":"blank"}]]}),
+            json!({"sheetIndex":0,"startRow":0,"startCol":16383,"values":[[{"kind":"blank"},{"kind":"blank"}]]}),
+            json!({"sheetIndex":1,"startRow":0,"startCol":0,"values":[vec![json!({"kind":"blank"});10001]]}),
+            json!({"sheetIndex":2,"startRow":0,"startCol":0,"values":[[{"kind":"blank"}]]}),
+            json!({"sheetIndex":0,"startRow":0,"startCol":0,"unknown":true,"values":[[{"kind":"blank"}]]}),
+        ] {
+            assert!(session
+                .set_range_recalculate_json_core(&request.to_string())
+                .is_err());
+            assert_eq!(session.save_document_bytes_core().unwrap(), before);
+        }
+        let request = json!({"sheetIndex":0,"startRow":0,"startCol":0,"values":[[{"kind":"number","value":9}]]}).to_string();
+        let exact = format!(
+            "{request}{}",
+            " ".repeat(MAX_RANGE_EDIT_REQUEST_BYTES - request.len())
+        );
+        let error = session
+            .set_range_recalculate_json_core(&(exact.clone() + " "))
+            .unwrap_err();
+        assert_eq!(error.resource, Some("rangeEditRequestBytes"));
+        assert_eq!(session.save_document_bytes_core().unwrap(), before);
+        session.set_range_recalculate_json_core(&exact).unwrap();
+        assert_eq!(
+            session.workbook.sheets[0].cell(0, 0),
+            Some(&Cell::Number(9.0))
+        );
+        session.set_range_recalculate_json_core(&json!({
+            "sheetIndex":0,"startRow":0,"startCol":0,"values":vec![vec![json!({"kind":"blank"});100];100]
+        }).to_string()).unwrap();
+        assert_eq!(session.edit_state_value()["undoDepth"], 2);
+    }
+
+    #[test]
+    fn rectangular_paste_rejects_merged_interiors_but_accepts_original_anchor() {
+        let mut workbook = Workbook::new();
+        workbook.add_sheet("Merged").merge(1, 1, 2, 2);
+        let mut session =
+            RenderSession::new_core(&workbook.to_xlsx_checked().unwrap(), &[]).unwrap();
+        let before = session.save_document_bytes_core().unwrap();
+        for (row, col, values) in [
+            (1, 2, json!([[{"kind":"blank"}]])),
+            (
+                1,
+                1,
+                json!([[{"kind":"number","value":1},{"kind":"blank"}]]),
+            ),
+            (
+                0,
+                0,
+                json!([[{"kind":"blank"},{"kind":"blank"},{"kind":"blank"}],[{"kind":"blank"},{"kind":"blank"},{"kind":"blank"}]]),
+            ),
+        ] {
+            assert!(session
+                .set_range_recalculate_json_core(
+                    &json!({"sheetIndex":0,"startRow":row,"startCol":col,"values":values})
+                        .to_string()
+                )
+                .is_err());
+            assert_eq!(session.save_document_bytes_core().unwrap(), before);
+        }
+        session.set_range_recalculate_json_core(r#"{"sheetIndex":0,"startRow":1,"startCol":1,"values":[[{"kind":"number","value":3}]]}"#).unwrap();
+        assert_eq!(
+            session.workbook.sheets[0].cell(1, 1),
+            Some(&Cell::Number(3.0))
+        );
+    }
+
+    #[test]
+    fn rectangular_paste_preserves_existing_fallbacks_and_fails_closed_on_shared_budget() {
+        let mut workbook = Workbook::new();
+        workbook
+            .add_sheet("Data")
+            .write_formula(0, 0, "UNKNOWNFUNCTION()", 42.0);
+        let mut session =
+            RenderSession::new_core(&workbook.to_xlsx_checked().unwrap(), &[]).unwrap();
+        let request = r#"{"sheetIndex":0,"startRow":0,"startCol":1,"values":[[{"kind":"number","value":3}]]}"#;
+        let result: serde_json::Value =
+            serde_json::from_str(&session.set_range_recalculate_json_core(request).unwrap())
+                .unwrap();
+        assert_eq!(result["recalculation"]["unsupportedCells"], 1);
+        assert_eq!(
+            session.workbook.sheets[0].cell(0, 0).unwrap().as_f64(),
+            Some(42.0)
+        );
+        let mut workbook = Workbook::new();
+        let sheet = workbook.add_sheet("Data");
+        for row in 0..10001 {
+            sheet.write_formula(row, 0, "1+1", 2.0);
+        }
+        let mut session =
+            RenderSession::new_core(&workbook.to_xlsx_checked().unwrap(), &[]).unwrap();
+        let before = session.save_document_bytes_core().unwrap();
+        assert_eq!(
+            session
+                .set_range_recalculate_json_core(request)
+                .unwrap_err()
+                .code,
+            "recalculation_failed"
+        );
+        assert_eq!(session.save_document_bytes_core().unwrap(), before);
+        assert_eq!(session.edit_state_value()["undoDepth"], 0);
+    }
+
+    #[test]
+    fn rectangular_paste_rejects_legacy_formats_and_preserves_xlsm_history() {
+        for bytes in [
+            include_bytes!("../../../tests/fixtures/xls/reader-basic.xls").as_slice(),
+            include_bytes!("../../../tests/fixtures/ods/repeated-hidden.ods").as_slice(),
+            include_bytes!("../../../tests/fixtures/xlsb/reader-basic.xlsb").as_slice(),
+        ] {
+            let mut session = RenderSession::new_core(bytes, &[]).unwrap();
+            assert_eq!(session.set_range_recalculate_json_core(r#"{"sheetIndex":0,"startRow":0,"startCol":0,"values":[[{"kind":"number","value":3}]]}"#).unwrap_err().code, "edit_read_only");
+            assert_eq!(session.edit_state_value()["undoDepth"], 0);
+        }
+        let bytes = include_bytes!("../../../viewer/samples/apache-poi-simple-macro.xlsm");
+        let mut session = RenderSession::new_core(bytes, &[]).unwrap();
+        let before = session.save_document_bytes_core().unwrap();
+        session.set_range_recalculate_json_core(r#"{"sheetIndex":0,"startRow":0,"startCol":0,"values":[[{"kind":"number","value":3},{"kind":"text","value":"batch"}]]}"#).unwrap();
+        assert!(session
+            .edited_parts
+            .iter()
+            .all(|part| part.starts_with("xl/worksheets/")));
+        let saved = session.save_document_bytes_core().unwrap();
+        session.undo_edit_core().unwrap();
+        assert_eq!(session.save_document_bytes_core().unwrap(), before);
+        session.redo_edit_core().unwrap();
+        assert_eq!(session.save_document_bytes_core().unwrap(), saved);
+    }
+}

--- a/bindings/render-wasm/src/recalculation.rs
+++ b/bindings/render-wasm/src/recalculation.rs
@@ -35,11 +35,13 @@ impl Summary {
 pub(super) fn apply(
     candidate: &mut Spreadsheet,
     workbook: &Workbook,
+    required_formulas: &std::collections::BTreeSet<(usize, u32, u16)>,
 ) -> Result<Summary, FacadeError> {
     let mut targets = Vec::new();
     let mut originals = Vec::new();
+    let mut required = Vec::new();
     let mut sheet_names = std::collections::BTreeSet::new();
-    for sheet in &workbook.sheets {
+    for (sheet_index, sheet) in workbook.sheets.iter().enumerate() {
         if !sheet_names.insert(sheet.name.to_ascii_lowercase()) {
             return Err(failure("ambiguous_sheet_names"));
         }
@@ -52,16 +54,23 @@ pub(super) fn apply(
                 }
                 targets.push((sheet.name.as_str(), cell.row, cell.col));
                 originals.push(cached.as_ref());
+                required.push(required_formulas.contains(&(sheet_index, cell.row, cell.col)));
             }
         }
+    }
+    if required.iter().filter(|&&value| value).count() != required_formulas.len() {
+        return Err(failure("missing_pasted_formula"));
     }
     let evaluated = workbook
         .evaluate_cells(&targets)
         .map_err(|reason| failure(reason.code()))?;
     let mut summary = Summary::default();
     let mut updates = Vec::new();
-    for (((sheet, row, col), cached), evaluation) in
-        targets.into_iter().zip(originals).zip(evaluated)
+    for ((((sheet, row, col), cached), evaluation), required) in targets
+        .into_iter()
+        .zip(originals)
+        .zip(evaluated)
+        .zip(required)
     {
         match evaluation {
             FormulaEvaluation::Computed(value) => {
@@ -80,6 +89,9 @@ pub(super) fn apply(
                 }
             }
             FormulaEvaluation::Fallback { reason, .. } => {
+                if required {
+                    return Err(super::unsupported_automatic_formula(reason.code()));
+                }
                 summary.unsupported_cells += 1;
                 if !summary.reasons.contains(&reason.code()) {
                     summary.reasons.push(reason.code());

--- a/bindings/render-wasm/tests/browser/scenario.mjs
+++ b/bindings/render-wasm/tests/browser/scenario.mjs
@@ -213,6 +213,33 @@ export async function runBrowserScenario({
         savedFormula.value.cached.value !== 6) throw new Error("saved dependent cache was stale");
     await client.closeDocument(reopenedRecalculation.documentId);
 
+    result.textContent = "STEP atomic rectangular paste";
+    const rangeDocument = await timed(client.open(fixture.workbook, { documentId: "browser-range" }), "open range fixture");
+    const rangeBefore = await Promise.all([0, 1].map((col) => timed(client.readCell(rangeDocument.documentId, 0, 0, col), "read original paste target")));
+    const pasted = await timed(client.setRangeAndRecalculate(rangeDocument.documentId, 0, 0, 0, [[
+      { kind: "number", value: 7 }, { kind: "formula-auto", formula: "=A1*3" }
+    ]]), "atomic rectangular paste");
+    if (pasted.editState.undoDepth !== 1 || pasted.recalculation.unsupportedCells !== 0) {
+      throw new Error("range paste did not produce one clean atomic undo entry");
+    }
+    await timed(client.undoEdit(rangeDocument.documentId), "undo rectangular paste");
+    for (let col = 0; col < 2; col += 1) {
+      const restored = await timed(client.readCell(rangeDocument.documentId, 0, 0, col), "read undone paste target");
+      if (JSON.stringify(restored.value) !== JSON.stringify(rangeBefore[col].value)) {
+        throw new Error("one undo did not restore every pasted cell");
+      }
+    }
+    await timed(client.redoEdit(rangeDocument.documentId), "redo rectangular paste");
+    const rangeSaved = await timed(client.saveDocument(rangeDocument.documentId), "save pasted workbook");
+    await client.closeDocument(rangeDocument.documentId);
+    const rangeReopened = await timed(client.open(rangeSaved.bytes, { documentId: "browser-range-saved" }), "reopen pasted workbook");
+    const rangeFormula = await timed(client.readCell(rangeReopened.documentId, 0, 0, 1), "read pasted formula cache");
+    if (rangeFormula.value.kind !== "formula" || rangeFormula.value.formula !== "A1*3" ||
+        rangeFormula.value.cached.kind !== "number" || rangeFormula.value.cached.value !== 21) {
+      throw new Error("pasted formula source or atomic computed cache was not preserved");
+    }
+    await client.closeDocument(rangeReopened.documentId);
+
     result.textContent = "STEP pagination";
     const pageMap = await timed(
       client.preparePages(opened.documentId, 0),

--- a/bindings/render-wasm/tests/interactive-sheet.test.mjs
+++ b/bindings/render-wasm/tests/interactive-sheet.test.mjs
@@ -201,6 +201,10 @@ async function runtimeHarness({ render = () => JSON.stringify(output()), limits 
     calls.push(["set-cell-recalculate", JSON.parse(json)]);
     return JSON.stringify({ workbook, editState, recalculation: recalculation() });
   };
+  if (!legacy) Session.prototype.setRangeRecalculateJson = function (json) {
+    calls.push(["set-range-recalculate", JSON.parse(json)]);
+    return JSON.stringify({ workbook, editState, recalculation: recalculation() });
+  };
   const capabilities = structuredClone(EXPECTED_CAPABILITIES);
   Object.assign(capabilities.limits, limits);
   const runtime = new RenderWorkerRuntime({
@@ -400,5 +404,113 @@ test("plain set-cell still rejects a recalculation summary as an extra field", a
   await h.settle();
   worker.emit(h.result(pending.requestId));
   await assert.rejects(pending, { code: "worker_message_error" });
+  h.runtime.closeAll();
+});
+
+const rangePayload = (values = [[{ kind: "number", value: 7 }]]) => ({
+  documentId: "doc", sheetIndex: 0, startRow: 0, startCol: 0, values
+});
+
+test("rectangular edits are authoritative, isolated, and preserve the recalculation response", async () => {
+  const h = await runtimeHarness();
+  const worker = new FakeWorker();
+  const client = new RenderWorkerClient(worker);
+  const values = [[{ kind: "number", value: 7 }, { kind: "formula-auto", formula: "=A1+1" }]];
+  const pending = client.setRangeAndRecalculate("doc", 0, 0, 0, values);
+  values[0][1].formula = "mutated";
+  values.push([{ kind: "blank" }]);
+  worker.emit({ protocol: protocol.PROTOCOL, type: "ready", capabilities: structuredClone(EXPECTED_CAPABILITIES) });
+  assert.equal(worker.sent[0].operation, "set-range-recalculate");
+  assert.equal(worker.sent[0].payload.values.length, 1);
+  assert.equal(worker.sent[0].payload.values[0][1].formula, "=A1+1");
+  assert.equal(client.cancel(pending.requestId), false);
+  h.runtime.receive(worker.sent[0]);
+  await h.settle();
+  worker.emit(h.result(pending.requestId));
+  assert.equal((await pending).recalculation.computedCells, 2);
+  assert.deepEqual(h.calls.find(([op]) => op === "set-range-recalculate")[1], {
+    sheetIndex: 0, startRow: 0, startCol: 0,
+    values: [[{ kind: "number", value: 7 }, { kind: "formula-auto", formula: "=A1+1" }]]
+  });
+  client.terminate(); h.runtime.closeAll();
+});
+
+test("range preflight rejects empty, jagged, sparse, oversized, unknown and out-of-grid input", () => {
+  const invalid = [
+    rangePayload([]), rangePayload([[]]), rangePayload([[{ kind: "blank" }], []]),
+    rangePayload(new Array(2)), rangePayload([new Array(1)]),
+    rangePayload([{ get length() { throw new Error("row getter executed"); } }]),
+    rangePayload(Array.from({ length: 101 }, () => Array(100).fill({ kind: "blank" }))),
+    rangePayload([[{ kind: "number", value: Infinity }]]),
+    rangePayload([[{ kind: "formula-auto", formula: "=" }]]),
+    rangePayload([[{ kind: "blank", extra: "secret" }]]),
+    { ...rangePayload(), startRow: 1_048_576 },
+    { ...rangePayload([[{ kind: "blank" }, { kind: "blank" }]]), startCol: 16_383 },
+    { ...rangePayload(), extra: 1 },
+    rangePayload(Object.assign([[{ kind: "blank" }]], { extra: 1 })),
+    rangePayload([[Object.defineProperty({}, "kind", { enumerable: true, get() { throw new Error("getter executed"); } })]])
+  ];
+  for (const payload of invalid) {
+    assert.throws(() => protocol.preflightRequest({ operation: "set-range-recalculate", payload }),
+      (error) => error instanceof protocol.RenderProtocolError && error.code !== "unknown_operation");
+  }
+});
+
+test("range requests have an exact 1MiB UTF-8/JSON budget without raising the single-cell limit", () => {
+  const values = Array.from({ length: 10 }, () => [{ kind: "text", value: "x".repeat(20_000) }]);
+  const payload = rangePayload(values);
+  const request = { sheetIndex: 0, startRow: 0, startCol: 0, values };
+  assert.equal(protocol.preflightRequest({ operation: "set-range-recalculate", payload }),
+    new TextEncoder().encode(JSON.stringify(request)).byteLength);
+  const expanded = rangePayload(Array.from({ length: 10 }, () => [{ kind: "text", value: "\u0000".repeat(20_000) }]));
+  assert.throws(() => protocol.preflightRequest({ operation: "set-range-recalculate", payload: expanded }),
+    (error) => error.resource === "editRequestBytes" && error.limit === 1_048_576);
+  assert.throws(() => protocol.preflightRequest({ operation: "set-cell", payload: {
+    documentId: "doc", sheetIndex: 0, row: 0, col: 0, value: { kind: "text", value: "x".repeat(140_000) }
+  } }), (error) => error.limit === 131_072);
+  const unicode = rangePayload([[{ kind: "text", value: "한국😀\ud800\n" }]]);
+  assert.equal(protocol.preflightRequest({ operation: "set-range-recalculate", payload: unicode }),
+    new TextEncoder().encode(JSON.stringify({ sheetIndex: 0, startRow: 0, startCol: 0, values: unicode.values })).byteLength);
+  const boundary = rangePayload(Array.from({ length: 9 }, () => [{ kind: "text", value: "x".repeat(120_000) }]));
+  boundary.values[8][0].value = "";
+  const prefixBytes = protocol.preflightRequest({ operation: "set-range-recalculate", payload: boundary });
+  boundary.values[8][0].value = "x".repeat(1_048_576 - prefixBytes);
+  assert.equal(protocol.preflightRequest({ operation: "set-range-recalculate", payload: boundary }), 1_048_576);
+  boundary.values[8][0].value += "x";
+  assert.throws(() => protocol.preflightRequest({ operation: "set-range-recalculate", payload: boundary }),
+    (error) => error.limit === 1_048_576 && error.actual === 1_048_577);
+  assert.throws(() => protocol.preflightRequest({ operation: "set-range-recalculate", payload: rangePayload([[{
+    kind: "text", value: "\u0000".repeat(25_000)
+  }]]) }), (error) => error.limit === 131_072);
+  const tenThousand = rangePayload(Array.from({ length: 100 }, () => Array(100).fill({ kind: "blank" })));
+  assert.ok(protocol.preflightRequest({ operation: "set-range-recalculate", payload: tenThousand }) < 1_048_576);
+});
+
+test("range response validation rejects malformed summaries and document drift", async () => {
+  for (const mutate of [
+    (result) => { result.documentId = "other"; },
+    (result) => { result.recalculation.unchangedCells = 9; },
+    (result) => { result.extra = 1; }
+  ]) {
+    const h = await runtimeHarness();
+    const { client, worker } = clientHarness();
+    const pending = client.setRangeAndRecalculate("doc", 0, 0, 0, [[{ kind: "blank" }]]);
+    h.runtime.receive(worker.sent[0]); await h.settle();
+    const reply = h.result(pending.requestId); mutate(reply.result); worker.emit(reply);
+    await assert.rejects(pending, { code: "worker_message_error" });
+    h.runtime.closeAll();
+  }
+});
+
+test("range editing is optional for legacy adapters and malformed requests never enter WASM", async () => {
+  const h = await runtimeHarness({ legacy: true });
+  h.request("range", "set-range-recalculate", rangePayload());
+  h.request("invalid", "set-range-recalculate", rangePayload([[]]));
+  h.request("plain", "set-cell", { documentId: "doc", sheetIndex: 0, row: 0, col: 0, value: { kind: "blank" } });
+  await h.settle();
+  assert.equal(h.result("range").error.code, "wasm_api_mismatch");
+  assert.equal(h.result("invalid").ok, false);
+  assert.equal(h.result("plain").ok, true);
+  assert.equal(h.calls.filter(([op]) => op === "set-range-recalculate").length, 0);
   h.runtime.closeAll();
 });

--- a/bindings/render-wasm/tests/typescript-consumer.test.mjs
+++ b/bindings/render-wasm/tests/typescript-consumer.test.mjs
@@ -208,6 +208,17 @@ const recalculated: RenderRequest<RecalculatedEditResult> = client.setCellAndRec
 const genericRecalculated: RenderRequest<RecalculatedEditResult> = client.request("set-cell-recalculate",
   { documentId: "document-1", sheetIndex: 0, row: 0, col: 0, value: automatic });
 void [recalculated, genericRecalculated];
+const rangeRecalculated: RenderRequest<RecalculatedEditResult> = client.setRangeAndRecalculate(
+  "document-1", 0, 0, 0, [[automatic, { kind: "number", value: 7 }]], requestOptions,
+);
+const genericRange: RenderRequest<RecalculatedEditResult> = client.request("set-range-recalculate", {
+  documentId: "document-1", sheetIndex: 0, startRow: 0, startCol: 0, values: [[automatic]],
+});
+void [rangeRecalculated, genericRange];
+// @ts-expect-error Range input is a matrix of typed cells, not scalar numbers.
+client.setRangeAndRecalculate("document-1", 0, 0, 0, [[7]]);
+// @ts-expect-error Range payload uses startRow/startCol and a values matrix.
+client.request("set-range-recalculate", { documentId: "document-1", sheetIndex: 0, row: 0, col: 0, value: automatic });
 // @ts-expect-error Geometry tuples have exactly six numeric elements.
 const shortGeometry: RenderCellGeometry = [0, 0, 0, 0, 100];
 // @ts-expect-error Sidecars carry geometry, not workbook text.

--- a/fuzz/fuzz_targets/edit.rs
+++ b/fuzz/fuzz_targets/edit.rs
@@ -16,6 +16,8 @@ use rxls::{Cell, Color, DocProperties, SheetVisible, Spreadsheet};
 
 /// Bound on Unstructured-derived loop counts so the target stays fast.
 const MAX_ITERS: u8 = 8;
+/// Keep rectangular transactions small while varying shape and clear/write cells.
+const MAX_RANGE_SIDE: usize = 4;
 
 fn arbitrary_cell(u: &mut Unstructured) -> Cell {
     match u.int_in_range(0u8..=5).unwrap_or(0) {
@@ -78,7 +80,7 @@ fuzz_target!(|data: &[u8]| {
         }
         let name = &names[u.int_in_range(0usize..=names.len() - 1).unwrap_or(0)];
         let (row, col) = arbitrary_coord(&mut u);
-        match u.int_in_range(0u8..=9).unwrap_or(0) {
+        match u.int_in_range(0u8..=10).unwrap_or(0) {
             0 => {
                 let value = arbitrary_cell(&mut u);
                 let _ = sheet.set_cell_value(name, row, col, value);
@@ -145,6 +147,31 @@ fuzz_target!(|data: &[u8]| {
             }
             8 => {
                 let _ = sheet.set_active_sheet(name);
+            }
+            9 => {
+                let rows = u.int_in_range(0usize..=MAX_RANGE_SIDE).unwrap_or(0);
+                let cols = u.int_in_range(0usize..=MAX_RANGE_SIDE).unwrap_or(0);
+                let mut values: Vec<Vec<Option<Cell>>> = (0..rows)
+                    .map(|_| {
+                        (0..cols)
+                            .map(|_| {
+                                if bool::arbitrary(&mut u).unwrap_or(false) {
+                                    Some(arbitrary_cell(&mut u))
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect()
+                    })
+                    .collect();
+                // Empty and occasionally ragged matrices cover rejection paths
+                // alongside the normal <=16-cell rectangular transaction.
+                if u.ratio(1u8, 4).unwrap_or(false) {
+                    if let Some(last) = values.last_mut() {
+                        let _ = last.pop();
+                    }
+                }
+                let _ = sheet.set_cell_range_values(name, row, col, &values);
             }
             _ => {
                 let rgb = <[u8; 3]>::arbitrary(&mut u).unwrap_or([0, 0, 0]);

--- a/scripts/check_workflow_policy.py
+++ b/scripts/check_workflow_policy.py
@@ -27,6 +27,9 @@ SEMVER_CHECKS_VERSION = "0.49.0"
 SEMVER_BASELINE_VERSION = "0.1.2"
 SEMVER_RELEASE_TYPE = "patch"
 CORE_RELEASE_TAG_PATTERN = "v[0-9]*.[0-9]*.[0-9]*"
+# The shared handoff executes in both read-only and privileged jobs. Changes to
+# its commands, budgets, or authentication require an explicit policy review.
+CORE_HANDOFF_HELPER_SHA256 = "2748295a2f32b22f674d39a69b25e26eef88f4154122748e11681f52cc8c689b"
 SEMVER_FEATURE_MODES = (
     "--all-features",
     "--default-features",
@@ -2025,13 +2028,15 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
     active = _without_commented_lines(text)
     errors: list[str] = []
     jobs = _single_yaml_block(path, active, "jobs:", 0, "core release jobs", errors)
-    if _yaml_mapping_entries_at_indent(jobs, 2) != [("verify", ""), ("publish", "")]:
+    if _yaml_mapping_entries_at_indent(jobs, 2) != [("verify", ""), ("rehearse", ""), ("publish", "")]:
         errors.append(f"{path}: core release must separate verify and publish jobs")
     verify_job = _single_yaml_block(path, jobs, "verify:", 2, "read-only verification job", errors)
     publish_job = _single_yaml_block(path, jobs, "publish:", 2, "privileged publication job", errors)
+    rehearse_job = _single_yaml_block(path, jobs, "rehearse:", 2, "read-only rehearsal job", errors)
     for block, indent, expected, label in (
         (active, 0, [("actions", "read"), ("contents", "read")], "workflow"),
         (verify_job, 4, [("actions", "read"), ("contents", "read")], "verification"),
+        (rehearse_job, 4, [("actions", "read"), ("contents", "read")], "rehearsal"),
         (publish_job, 4, [("actions", "read"), ("contents", "write")], "publication"),
     ):
         permissions = _single_yaml_block(path, block, "permissions:", indent, f"{label} permissions", errors)
@@ -2065,6 +2070,7 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
     outputs = _single_yaml_block(path, verify_job, "outputs:", 4, "verification outputs", errors)
     if _yaml_mapping_entries_at_indent(outputs, 6) != [
         ("version", "${{ steps.release.outputs.version }}"),
+        ("rehearse", "${{ steps.release.outputs.rehearse }}"),
         ("source_attempt", "${{ steps.release.outputs.source_attempt }}"),
         ("artifact_id", "${{ steps.publication_bundle.outputs.artifact-id }}"),
         ("artifact_digest", "${{ steps.publication_bundle.outputs.artifact-digest }}"),
@@ -2289,9 +2295,9 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
         errors.append(
             f"{path}: expected exactly one dependency-free crates.io dry-run runner"
         )
-    if len(verify_pattern.findall(active)) != 8:
+    if len(verify_pattern.findall(active)) != 7:
         errors.append(
-            f"{path}: expected eight exact crates.io dry-run evidence verifications"
+            f"{path}: expected seven in-workflow dry-run verifications plus the shared handoff helper"
         )
     if "cargo publish --dry-run" in active:
         errors.append(
@@ -2316,7 +2322,7 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
         errors.append(
             f"{path}: release identity step must bind the tag to exact origin/main"
         )
-    if active.count(exact_main) != 3:
+    if active.count(exact_main) != 4:
         errors.append(
             f"{path}: exact origin/main must be checked at tag validation and again "
             "at the publication handoff and immediately before crates.io publication"
@@ -2463,11 +2469,6 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
             "final publication assembly",
         ),
         (
-            "- name: Verify publication handoff and package bytes",
-            ["dist/release-cargo-publish-dry-run.json"],
-            "publication handoff",
-        ),
-        (
             "- name: Verify published crate, WASM, docs, assets, and checksums",
             ['"$smoke/assets/release-cargo-publish-dry-run.json"'],
             "post-download release verification",
@@ -2562,7 +2563,7 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
         errors.append(
             f"{path}: candidate bundle must be verified twice at exactly 48 files"
         )
-    if active.count("--expected-files 52") != 4:
+    if active.count("--expected-files 52") != 3:
         errors.append(
             f"{path}: public bundle must be assembled, transferred, published, and downloaded "
             "at exactly 52 files"
@@ -2691,6 +2692,7 @@ def audit_core_release_evidence(path: Path, text: str) -> list[str]:
             f"{path}: wildcard GitHub Release upload must not bypass exact inventory"
         )
     errors.extend(_audit_core_publication_handoff(path, verify_job, publish_job))
+    errors.extend(_audit_core_rehearsal(path, active, verify_job, rehearse_job))
     return errors
 
 
@@ -2723,77 +2725,157 @@ def _audit_core_publication_handoff(path: Path, verify_job: str, publish_job: st
             errors.append(f"{path}: publication identity must retain {required!r}")
     upload = _single_yaml_block(path, verify_job, "- name: Upload verified publication bundle", 6, "publication bundle upload", errors)
     for required in (
-        "id: publication_bundle", "if: github.event_name == 'push'",
+        "id: publication_bundle", "if: github.event_name == 'push' || steps.release.outputs.rehearse == 'true'",
         "name: rxls-${{ steps.release.outputs.version }}-publication-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}",
         "path: dist/*", "if-no-files-found: error",
     ):
         if upload.count(required) != 1:
             errors.append(f"{path}: publication bundle upload must retain {required!r}")
-    download = _single_yaml_block(path, publish_job, "- name: Download exact verified publication bundle", 6, "publication bundle download", errors)
+    errors.extend(_audit_core_handoff_steps(
+        path, publish_job, "Authenticate verified publication artifact",
+        "Download exact verified publication bundle", "Verify publication handoff and package bytes",
+    ))
+    handoff_at = publish_job.find("- name: Verify publication handoff and package bytes")
+    if not 0 <= handoff_at < publish_job.find("- name: Publish to crates.io"):
+        errors.append(f"{path}: handoff must precede registry publication")
+    for block in (verify_job, publish_job):
+        if "rxls-0.1.3" in block or "--registry-version 0.1.3" in block:
+            errors.append(f"{path}: release paths must use validated versions")
+    if '"$smoke/assets/wasm-native-report.json"' not in publish_job:
+        errors.append(f"{path}: installed browser smoke must use the verified native report")
+    if "set -euo pipefail" not in identity or re.search(r"^ {8}if:", identity, re.MULTILINE):
+        errors.append(f"{path}: publication identity must run unconditionally and fail closed")
+    return errors
+
+
+def _audit_core_handoff_steps(path: Path, job: str, auth_name: str, download_name: str, verify_name: str) -> list[str]:
+    """Require identical artifact authentication and package checks in both jobs."""
+    errors: list[str] = []
+    env = _single_yaml_block(path, job, "env:", 4, "handoff environment", errors)
+    expected_env = [
+        ("ARTIFACT_ID", "${{ needs.verify.outputs.artifact_id }}"),
+        ("ARTIFACT_DIGEST", "${{ needs.verify.outputs.artifact_digest }}"),
+        ("SOURCE_ATTEMPT", "${{ needs.verify.outputs.source_attempt }}"),
+        ("VERIFIED_VERSION", "${{ needs.verify.outputs.version }}"),
+    ]
+    if _yaml_mapping_entries_at_indent(env, 6) != expected_env:
+        errors.append(f"{path}: handoff must use only the producing job's exact identity outputs")
+    auth = _single_yaml_block(path, job, f"- name: {auth_name}", 6, "artifact authentication", errors)
+    expected_auth = [
+        "set -euo pipefail",
+        '[[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]',
+        "mkdir -p target/publication",
+        'gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID" \\',
+        "  > target/publication/artifact.json",
+        "python3 scripts/core_release_handoff.py authenticate",
+    ]
+    scripts = _workflow_run_scripts("    steps:\n" + auth)
+    if len(scripts) != 1 or scripts[0].strip() != "\n".join(expected_auth):
+        errors.append(f"{path}: artifact authentication must use the exact shared helper")
+    if "GH_TOKEN: ${{ github.token }}" not in auth:
+        errors.append(f"{path}: artifact reads must use the scoped workflow token")
+    download = _single_yaml_block(path, job, f"- name: {download_name}", 6, "exact artifact transfer", errors)
     expected_download = [
         ("artifact-ids", "${{ needs.verify.outputs.artifact_id }}"),
         ("path", "dist"), ("merge-multiple", "true"), ("digest-mismatch", "error"),
     ]
     if _yaml_mapping_entries_at_indent(download, 10) != expected_download:
-        errors.append(f"{path}: publication download must use exact immutable ID and fail on digest mismatch")
-    metadata = _single_yaml_block(path, publish_job, "- name: Authenticate verified publication artifact", 6, "publication artifact authentication", errors)
-    for required in (
-        "GH_TOKEN: ${{ github.token }}",
-        "ARTIFACT_ID: ${{ needs.verify.outputs.artifact_id }}",
-        "ARTIFACT_DIGEST: ${{ needs.verify.outputs.artifact_digest }}",
-        "SOURCE_ATTEMPT: ${{ needs.verify.outputs.source_attempt }}",
-        "VERIFIED_VERSION: ${{ needs.verify.outputs.version }}",
-        '[[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]',
-        'gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID"',
-        'expected_digest = os.environ["ARTIFACT_DIGEST"].removeprefix("sha256:")',
-        'if not re.fullmatch(r"[0-9a-f]{64}", expected_digest):',
-        'if not re.fullmatch(r"[1-9][0-9]*", attempt) or int(attempt) > int(os.environ["GITHUB_RUN_ATTEMPT"]):',
-        'f"rxls-{os.environ[\'VERIFIED_VERSION\']}-publication-"',
-        'f"{os.environ[\'GITHUB_SHA\']}-{os.environ[\'GITHUB_RUN_ID\']}-{attempt}"',
-        '"id": int(os.environ["ARTIFACT_ID"]),',
-        '"name": expected_name,', '"digest": f"sha256:{expected_digest}",',
-        '"expired": False,',
-        'if any(type(artifact.get(key)) is not type(value) or artifact[key] != value for key, value in expected.items()):',
-        '"id": int(os.environ["GITHUB_RUN_ID"]),',
-        '"head_sha": os.environ["GITHUB_SHA"],',
-        '"repository_id": int(os.environ["GITHUB_REPOSITORY_ID"]),',
-        '"head_repository_id": int(os.environ["GITHUB_REPOSITORY_ID"]),',
-        'if not isinstance(run, dict) or any(type(run.get(key)) is not type(value) or run[key] != value for key, value in expected_run.items()):',
-    ):
-        if metadata.count(required) != 1:
-            errors.append(f"{path}: publication artifact authentication must retain {required!r}")
-    handoff = _single_yaml_block(path, publish_job, "- name: Verify publication handoff and package bytes", 6, "publication package handoff", errors)
-    for required in (
-        "python3 scripts/check_workflow_policy.py", "python3 scripts/check_release_identity.py",
-        "--verify-bundle dist", "--expected-files 52",
-        'python3 scripts/check_core_package.py "dist/rxls-${version}.crate"',
-        "cargo package --locked",
-        'cmp "target/package/rxls-${version}.crate" "dist/rxls-${version}.crate"',
-    ):
-        if handoff.count(required) != 1:
-            errors.append(f"{path}: publication package handoff must retain {required!r}")
-    if not (0 <= handoff.find("cargo package --locked") < handoff.find('cmp "target/package/')):
-        errors.append(f"{path}: publication must compare the newly packed crate bytes")
-    ordered_headers = (
-        "- name: Authenticate verified publication artifact",
-        "- name: Download exact verified publication bundle",
-        "- name: Verify publication handoff and package bytes",
-        "- name: Publish to crates.io",
-    )
-    positions = [publish_job.find(header) for header in ordered_headers]
+        errors.append(f"{path}: transfer must use the exact artifact ID and enforce its digest")
+    verifier = _single_yaml_block(path, job, f"- name: {verify_name}", 6, "shared package verification", errors)
+    if _yaml_mapping_entries_at_indent(verifier, 8) != [("run", "python3 scripts/core_release_handoff.py verify")]:
+        errors.append(f"{path}: package transfer must use the unconditional shared verification helper")
+    positions = [job.find(f"- name: {name}") for name in (auth_name, download_name, verify_name)]
     if not all(left >= 0 and left < right for left, right in zip(positions, positions[1:])):
-        errors.append(f"{path}: publication must authenticate, download, and verify before publishing")
-    for block in (identity, metadata, handoff):
-        if "set -euo pipefail" not in block or re.search(r"^ {8}if:", block, re.MULTILINE):
-            errors.append(f"{path}: critical publication gates must run unconditionally and fail closed")
-    if re.search(r"^ {8}if:", download, re.MULTILINE):
-        errors.append(f"{path}: publication download must not be conditionally skipped")
-    for block in (verify_job, publish_job):
-        if "rxls-0.1.3" in block or "--registry-version 0.1.3" in block:
-            errors.append(f"{path}: release package names and registry smokes must use validated version")
-    if '"$smoke/assets/wasm-native-report.json"' not in publish_job:
-        errors.append(f"{path}: installed browser smoke must use the verified native report")
+        errors.append(f"{path}: handoff must authenticate, transfer, then verify")
+    for block in (auth, download, verifier):
+        if any(key in {"if", "continue-on-error"} for key, _ in _yaml_mapping_entries_at_indent(block, 8)):
+            errors.append(f"{path}: handoff checks must not be skipped or bypassed")
     return errors
+
+
+def _audit_core_rehearsal(path: Path, active: str, verify_job: str, rehearsal: str) -> list[str]:
+    """Keep manual rehearsal read-only and behind the real release evidence."""
+    errors: list[str] = []
+    expected_guard = (
+        "github.repository == 'HyunjoJung/rxls' && github.event_name == 'workflow_dispatch' "
+        "&& github.ref == 'refs/heads/main' && needs.verify.outputs.rehearse == 'true'"
+    )
+    fields = dict(_yaml_mapping_entries_at_indent(rehearsal, 4))
+    for key, expected in (("needs", "verify"), ("if", expected_guard), ("timeout-minutes", "30")):
+        if fields.get(key) != expected:
+            errors.append(f"{path}: rehearsal must retain exact {key} guard")
+    if any(token in rehearsal for token in ("secrets.", "environment:", "cargo publish", "gh release", "contents: write")):
+        errors.append(f"{path}: rehearsal must have no publication authority")
+    input_block = _single_yaml_block(path, active, "rehearse_publication:", 6, "typed rehearsal input", errors)
+    if dict(_yaml_mapping_entries_at_indent(input_block, 8)) != {
+        "description": '"Rehearse the exact verified publication handoff without publishing"',
+        "required": "false", "default": "false", "type": "boolean",
+    }:
+        errors.append(f"{path}: rehearsal input must be an explicit default-false boolean")
+    identity = _single_yaml_block(path, verify_job, "- name: Validate release identity", 6, "early release identity", errors)
+    for required in (
+        "REQUEST_REHEARSAL: ${{ github.event_name == 'workflow_dispatch' && toJSON(inputs.rehearse_publication) || 'false' }}",
+        "BASELINE_RUN_ID: ${{ inputs.baseline_run_id }}",
+        'case "$REQUEST_REHEARSAL" in', 'true|false) ;;',
+        '*) echo "rehearsal input must be a boolean" >&2; exit 1 ;;',
+        'if [[ "$REQUEST_REHEARSAL" == "true" ]]; then',
+        'test "$GITHUB_EVENT_NAME" = "workflow_dispatch"',
+        'test "$GITHUB_REPOSITORY" = "HyunjoJung/rxls"',
+        'test "$GITHUB_REF" = "refs/heads/main"',
+        'test -z "$BASELINE_RUN_ID" || {',
+        'echo "rehearse=$REQUEST_REHEARSAL" >> "$GITHUB_OUTPUT"',
+    ):
+        if identity.count(required) != 1:
+            errors.append(f"{path}: early rehearsal identity must retain {required!r}")
+    gate_names = (
+        "Require successful exact-SHA CI and CodeQL runs",
+        "Require exact-SHA two-candidate publication attestation",
+        "Bind publication provenance into release manifest",
+        "Upload verified publication bundle",
+    )
+    for name in gate_names:
+        block = _single_yaml_block(path, verify_job, f"- name: {name}", 6, name, errors)
+        conditions = [value for key, value in _yaml_mapping_entries_at_indent(block, 8) if key == "if"]
+        if conditions != ["github.event_name == 'push' || steps.release.outputs.rehearse == 'true'"]:
+            errors.append(f"{path}: rehearsal must retain the actual {name} gate")
+    checkout = _single_yaml_block(path, rehearsal, f"- uses: {ORACLE_CHECKOUT_ACTION} # v7.0.1", 6, "rehearsal checkout", errors)
+    for required in ("ref: ${{ github.sha }}", "fetch-depth: 0", "persist-credentials: false"):
+        if checkout.count(required) != 1:
+            errors.append(f"{path}: rehearsal checkout must retain {required}")
+    identity = _single_yaml_block(path, rehearsal, "- name: Validate rehearsal identity", 6, "rehearsal source identity", errors)
+    expected_identity = [
+        "set -euo pipefail", 'test "$GITHUB_REPOSITORY" = "HyunjoJung/rxls"',
+        'test "$GITHUB_EVENT_NAME" = "workflow_dispatch"',
+        'test "$GITHUB_REF" = "refs/heads/main"',
+        'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"',
+        "git fetch origin main --no-tags",
+        'test "$(git rev-parse origin/main)" = "$GITHUB_SHA"',
+    ]
+    scripts = _workflow_run_scripts("    steps:\n" + identity)
+    if len(scripts) != 1 or scripts[0].strip() != "\n".join(expected_identity):
+        errors.append(f"{path}: rehearsal must recheck exact canonical main before artifacts")
+    if any(key in {"if", "continue-on-error"} for key, _ in _yaml_mapping_entries_at_indent(identity, 8)):
+        errors.append(f"{path}: rehearsal source identity must not be skipped")
+    headers = re.findall(r"^ {6}(- (?:name|uses|run):[^\r\n]+)$", rehearsal, re.MULTILINE)
+    if len(headers) < 2 or headers[1] != "- name: Validate rehearsal identity":
+        errors.append(f"{path}: rehearsal identity must immediately follow checkout")
+    errors.extend(_audit_core_handoff_steps(
+        path, rehearsal, "Authenticate rehearsal artifact",
+        "Download exact rehearsal bundle", "Rehearse publication handoff and package bytes",
+    ))
+    receipt = _single_yaml_block(path, rehearsal, "- name: Upload successful rehearsal receipt", 6, "rehearsal receipt", errors)
+    if "if-no-files-found: error" not in receipt or "path: target/publication/handoff.json" not in receipt:
+        errors.append(f"{path}: successful rehearsal must retain its exact handoff receipt")
+    if any(key in {"if", "continue-on-error"} for key, _ in _yaml_mapping_entries_at_indent(receipt, 8)):
+        errors.append(f"{path}: rehearsal receipt must be uploaded only after successful verification")
+    return errors
+
+
+def audit_core_handoff_helper(path: Path, text: str) -> list[str]:
+    """Keep both receiving jobs on the reviewed bounded, non-publishing helper."""
+    if hashlib.sha256(text.encode("utf-8")).hexdigest() != CORE_HANDOFF_HELPER_SHA256:
+        return [f"{path}: shared release handoff differs from its reviewed implementation"]
+    return []
 
 
 def audit_github_release_reconciler(path: Path, text: str) -> list[str]:
@@ -6649,6 +6731,13 @@ def audit_repository(root: Path) -> list[str]:
         errors.extend(
             audit_core_release_evidence(release.relative_to(root), release_text)
         )
+    handoff_helper = root / "scripts" / "core_release_handoff.py"
+    if not handoff_helper.is_file():
+        errors.append(f"{handoff_helper.relative_to(root)}: missing shared release handoff verifier")
+    else:
+        errors.extend(audit_core_handoff_helper(
+            handoff_helper.relative_to(root), handoff_helper.read_text(encoding="utf-8")
+        ))
     github_release_reconciler = root / "scripts" / "reconcile_github_release.py"
     if not github_release_reconciler.is_file():
         errors.append(

--- a/scripts/core_release_handoff.py
+++ b/scripts/core_release_handoff.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Authenticate and verify a core release handoff, without publication authority.
+
+Both the read-only hosted rehearsal and tag publication use these checks. This
+helper never dispatches, tags, publishes, or accesses registry credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAX_METADATA_BYTES = 64 * 1024
+MAX_CRATE_BYTES = 1 << 20
+COMMAND_TIMEOUT = 1200
+SEMVER = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?")
+
+
+class HandoffError(ValueError):
+    """Fail-closed artifact or package identity failure."""
+
+
+def require(condition, message):
+    if not condition:
+        raise HandoffError(message)
+
+
+def read_bounded(path, limit):
+    require(not path.is_symlink() and path.is_file(), "expected a regular evidence file")
+    with path.open("rb") as stream:
+        data = stream.read(limit + 1)
+    require(len(data) <= limit, "evidence file exceeds its byte budget")
+    return data
+
+
+def load_metadata(path):
+    def unique(pairs):
+        result = {}
+        for key, value in pairs:
+            require(key not in result, "duplicate artifact metadata key")
+            result[key] = value
+        return result
+    return json.loads(read_bounded(path, MAX_METADATA_BYTES), object_pairs_hook=unique)
+
+
+def positive(env, name):
+    value = env.get(name, "")
+    require(isinstance(value, str) and re.fullmatch(r"[1-9][0-9]{0,18}", value), f"invalid {name}")
+    return int(value)
+
+
+def identity(env):
+    version, sha = env.get("VERIFIED_VERSION", ""), env.get("GITHUB_SHA", "")
+    require(isinstance(version, str) and len(version) <= 128 and SEMVER.fullmatch(version), "invalid verified version")
+    require(isinstance(sha, str) and re.fullmatch(r"[0-9a-f]{40}", sha), "invalid source SHA")
+    require(env.get("GITHUB_REPOSITORY") == "HyunjoJung/rxls", "foreign source repository")
+    return version, sha
+
+
+def authenticate(artifact, env):
+    version, sha = identity(env)
+    digest = env.get("ARTIFACT_DIGEST", "")
+    require(isinstance(digest, str) and len(digest) <= 71, "invalid artifact digest input")
+    digest = digest.removeprefix("sha256:")
+    require(re.fullmatch(r"[0-9a-f]{64}", digest), "invalid verified artifact digest")
+    attempt = positive(env, "SOURCE_ATTEMPT")
+    require(attempt <= positive(env, "GITHUB_RUN_ATTEMPT"), "invalid verified source attempt")
+    run_id, repository_id = positive(env, "GITHUB_RUN_ID"), positive(env, "GITHUB_REPOSITORY_ID")
+    expected = {
+        "id": positive(env, "ARTIFACT_ID"),
+        "name": f"rxls-{version}-publication-{sha}-{run_id}-{attempt}",
+        "digest": f"sha256:{digest}",
+        "expired": False,
+    }
+    require(isinstance(artifact, dict), "invalid publication artifact metadata")
+    require(all(type(artifact.get(key)) is type(value) and artifact[key] == value for key, value in expected.items()), "artifact identity differs from verified output")
+    run = artifact.get("workflow_run")
+    expected_run = {
+        "id": run_id, "head_sha": sha,
+        "repository_id": repository_id, "head_repository_id": repository_id,
+    }
+    require(isinstance(run, dict) and all(type(run.get(key)) is type(value) and run[key] == value for key, value in expected_run.items()), "artifact source differs from verified run")
+    return {"artifact_id": expected["id"], "artifact_digest": expected["digest"], "source_attempt": attempt}
+
+
+def checked_command(argv, root):
+    subprocess.run(argv, cwd=root, check=True, timeout=COMMAND_TIMEOUT)
+
+
+def verify(root, env, runner=checked_command):
+    """Validate transferred evidence and compare a newly built archive exactly."""
+    version, sha = identity(env)
+    artifact = authenticate(load_metadata(root / "target/publication/artifact.json"), env)
+    manifest = tomllib.loads(read_bounded(root / "Cargo.toml", MAX_METADATA_BYTES).decode("utf-8"))
+    require(manifest["package"]["version"] == version, "source manifest version differs")
+    commands = (
+        ["python3", "scripts/check_workflow_policy.py"],
+        ["python3", "scripts/check_release_identity.py"],
+        ["python3", "scripts/check_cargo_publish_dry_run.py", "verify", "--manifest", "Cargo.toml", "--git-sha", sha, "--receipt", "dist/release-cargo-publish-dry-run.json"],
+        ["python3", "scripts/release_manifest.py", "--verify-bundle", "dist", "--expected-files", "52", "--version", version, "--git-rev", sha],
+        ["python3", "scripts/check_core_package.py", f"dist/rxls-{version}.crate"],
+        ["cargo", "package", "--locked"],
+    )
+    for argv in commands:
+        runner(argv, root)
+    # Cargo has no stable publish-existing-archive command. The same clean,
+    # pinned source/toolchain must reproduce the transferred archive bytewise.
+    expected = read_bounded(root / f"dist/rxls-{version}.crate", MAX_CRATE_BYTES)
+    actual = read_bounded(root / f"target/package/rxls-{version}.crate", MAX_CRATE_BYTES)
+    require(actual == expected, "repacked crate differs from verified artifact bytes")
+    return {
+        "schema": "rxls.core-release-handoff.v1", "passed": True,
+        "publication_allowed": False, "version": version, "git_rev": sha,
+        "crate_bytes": len(actual), "crate_sha256": hashlib.sha256(actual).hexdigest(),
+        **artifact,
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("authenticate", "verify"))
+    args = parser.parse_args(argv)
+    try:
+        if args.operation == "authenticate":
+            result = authenticate(load_metadata(ROOT / "target/publication/artifact.json"), os.environ)
+        else:
+            result = verify(ROOT, os.environ)
+            receipt = ROOT / "target/publication/handoff.json"
+            require(not receipt.is_symlink(), "handoff receipt must not be a symlink")
+            receipt.write_text(json.dumps(result, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (HandoffError, OSError, ValueError, KeyError, TypeError, RecursionError, subprocess.SubprocessError) as error:
+        print(f"core release handoff failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_pipeline.py
+++ b/scripts/release_pipeline.py
@@ -40,6 +40,7 @@ STAGES = (
     ("viewer", "viewer-pages.yml", {"deploy": False}),
     ("core-baseline", "release.yml", {"baseline_run_id": ""}),
     ("core-compare", "release.yml", None),
+    ("core-rehearsal", "release.yml", {"baseline_run_id": "", "rehearse_publication": True}),
     ("render-package", "render-package-release.yml", {}),
 )
 STAGE_KEYS = {stage[0] for stage in STAGES}
@@ -273,7 +274,7 @@ def activate_checkout(root, sha, runner):
     origin = runner.run(["git", "remote", "get-url", "origin"]).strip()
     if origin not in {f"git@github.com:{REPOSITORY}.git", f"https://github.com/{REPOSITORY}.git", f"https://github.com/{REPOSITORY}"}:
         raise PipelineError("origin is not the canonical GitHub repository")
-    files = ["scripts/release_pipeline.py", "scripts/check_workflow_policy.py", "scripts/package-identities.json"] + [f".github/workflows/{stage[1]}" for stage in STAGES]
+    files = ["scripts/release_pipeline.py", "scripts/check_workflow_policy.py", "scripts/core_release_handoff.py", "scripts/package-identities.json"] + [f".github/workflows/{stage[1]}" for stage in STAGES]
     runner.run(["git", "ls-files", "--error-unmatch", "--", *files])
     runner.run(["git", "check-ignore", "--", f"target/release-pipeline/{sha}/state.json"])
     # Reuse the canonical semantic guard audit, including verification/deploy

--- a/scripts/test_core_release_handoff.py
+++ b/scripts/test_core_release_handoff.py
@@ -1,0 +1,124 @@
+"""Offline tests for the shared, non-publishing release handoff verifier."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("core_release_handoff", ROOT / "scripts/core_release_handoff.py")
+handoff = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(handoff)
+
+
+class HandoffTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.env = {
+            "ARTIFACT_ID": "456", "ARTIFACT_DIGEST": "a" * 64,
+            "SOURCE_ATTEMPT": "1", "VERIFIED_VERSION": "0.1.4",
+            "GITHUB_RUN_ID": "123", "GITHUB_RUN_ATTEMPT": "2",
+            "GITHUB_SHA": "b" * 40, "GITHUB_REPOSITORY_ID": "789",
+            "GITHUB_REPOSITORY": "HyunjoJung/rxls",
+        }
+        self.metadata = {
+            "id": 456, "name": f"rxls-0.1.4-publication-{'b' * 40}-123-1",
+            "digest": f"sha256:{'a' * 64}", "expired": False,
+            "workflow_run": {"id": 123, "head_sha": "b" * 40, "repository_id": 789, "head_repository_id": 789},
+        }
+        for relative in ("dist", "target/package", "target/publication"):
+            (self.root / relative).mkdir(parents=True)
+        self.metadata_path = self.root / "target/publication/artifact.json"
+        self.metadata_path.write_text(json.dumps(self.metadata), encoding="utf-8")
+        (self.root / "Cargo.toml").write_text('[package]\nname="rxls"\nversion="0.1.4"\n', encoding="utf-8")
+        self.archive = self.root / "dist/rxls-0.1.4.crate"
+        self.archive.write_bytes(b"verified archive")
+        self.commands = []
+
+    def runner(self, argv, root):
+        self.assertEqual(root, self.root)
+        self.commands.append(argv)
+        if argv == ["cargo", "package", "--locked"]:
+            (root / "target/package/rxls-0.1.4.crate").write_bytes(self.archive.read_bytes())
+
+    def test_shared_verifier_orders_real_gates_and_never_authorizes_publication(self):
+        result = handoff.verify(self.root, self.env, self.runner)
+        self.assertTrue(result["passed"])
+        self.assertFalse(result["publication_allowed"])
+        self.assertEqual(result["artifact_id"], 456)
+        self.assertEqual(result["source_attempt"], 1)
+        self.assertEqual(result["git_rev"], "b" * 40)
+        self.assertEqual([command[1] for command in self.commands], [
+            "scripts/check_workflow_policy.py", "scripts/check_release_identity.py",
+            "scripts/check_cargo_publish_dry_run.py", "scripts/release_manifest.py",
+            "scripts/check_core_package.py", "package",
+        ])
+        self.assertIn("52", self.commands[3])
+        self.assertIn("--git-sha", self.commands[2])
+        self.assertEqual(self.commands[-1], ["cargo", "package", "--locked"])
+        self.assertNotIn("publish", [argument for command in self.commands for argument in command])
+
+    def test_different_repacked_bytes_fail(self):
+        def mismatch(argv, root):
+            self.runner(argv, root)
+            if argv[0] == "cargo":
+                (root / "target/package/rxls-0.1.4.crate").write_bytes(b"different")
+        with self.assertRaisesRegex(handoff.HandoffError, "repacked crate"):
+            handoff.verify(self.root, self.env, mismatch)
+
+    def test_every_failed_evidence_gate_prevents_repack(self):
+        for failed in range(5):
+            self.commands = []
+            def fail(argv, root):
+                if len(self.commands) == failed:
+                    raise subprocess.CalledProcessError(1, argv)
+                self.runner(argv, root)
+            with self.subTest(gate=failed), self.assertRaises(subprocess.CalledProcessError):
+                handoff.verify(self.root, self.env, fail)
+            self.assertFalse(any(argv[0] == "cargo" for argv in self.commands))
+
+    def test_metadata_and_manifest_mismatch_fail_before_commands(self):
+        for env in (
+            {**self.env, "ARTIFACT_ID": "999"},
+            {**self.env, "GITHUB_REPOSITORY": "other/rxls"},
+            {**self.env, "SOURCE_ATTEMPT": "3"},
+            {**self.env, "ARTIFACT_DIGEST": None},
+        ):
+            with self.subTest(env=env), self.assertRaises(handoff.HandoffError):
+                handoff.verify(self.root, env, self.runner)
+        (self.root / "Cargo.toml").write_text('[package]\nversion="0.1.5"\n')
+        with self.assertRaisesRegex(handoff.HandoffError, "manifest version"):
+            handoff.verify(self.root, self.env, self.runner)
+        self.assertEqual(self.commands, [])
+
+    def test_evidence_files_are_bounded_regular_and_duplicate_free(self):
+        self.metadata_path.write_text('{"id":1,"id":2}')
+        with self.assertRaisesRegex(handoff.HandoffError, "duplicate"):
+            handoff.load_metadata(self.metadata_path)
+        self.metadata_path.write_bytes(b"x" * (handoff.MAX_METADATA_BYTES + 1))
+        with self.assertRaisesRegex(handoff.HandoffError, "byte budget"):
+            handoff.load_metadata(self.metadata_path)
+        self.metadata_path.unlink()
+        self.metadata_path.symlink_to(self.archive)
+        with self.assertRaisesRegex(handoff.HandoffError, "regular"):
+            handoff.load_metadata(self.metadata_path)
+
+    def test_subprocess_has_checked_status_timeout_and_no_shell(self):
+        with mock.patch.object(handoff.subprocess, "run") as run:
+            handoff.checked_command(["cargo", "package", "--locked"], self.root)
+        run.assert_called_once_with(
+            ["cargo", "package", "--locked"], cwd=self.root,
+            check=True, timeout=handoff.COMMAND_TIMEOUT,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_pipeline.py
+++ b/scripts/test_release_pipeline.py
@@ -174,16 +174,17 @@ class PipelineTests(unittest.TestCase):
         self.assertEqual(self.gh.posts, [])
 
     def test_two_pass_release_uses_exact_owned_first_run(self):
-        for _ in range(7):
+        for _ in pipeline.STAGES:
             result = self.cli.advance(execute=True)
             self.assertEqual(result["action"], "dispatched", result)
             record = self.store.load()["records"][result["next_stage"]]
             self.gh.runs[record["run_id"]].update(status="completed", conclusion="success")
         release_posts = [(endpoint, body) for endpoint, body in self.gh.posts if "/release.yml/" in endpoint]
-        self.assertEqual(len(release_posts), 2)
+        self.assertEqual(len(release_posts), 3)
         baseline = self.store.load()["records"]["core-baseline"]["run_id"]
         self.assertEqual(release_posts[0][1]["inputs"], {"baseline_run_id": ""})
         self.assertEqual(release_posts[1][1]["inputs"], {"baseline_run_id": str(baseline)})
+        self.assertEqual(release_posts[2][1]["inputs"], {"baseline_run_id": "", "rehearse_publication": True})
         self.assertEqual(self.cli.advance()["action"], "verification_runs_complete")
         self.assertFalse(self.cli.status()["publication_allowed"])
 
@@ -309,6 +310,7 @@ class AdapterTests(unittest.TestCase):
         runner.run.assert_any_call([pipeline.sys.executable, "scripts/check_workflow_policy.py", "--root", str(ROOT)])
         tracked = next(call.args[0] for call in runner.run.call_args_list if "ls-files" in call.args[0])
         self.assertIn("scripts/check_workflow_policy.py", tracked)
+        self.assertIn("scripts/core_release_handoff.py", tracked)
 
     def test_timeout_kills_group_even_after_leader_exits_with_open_pipes(self):
         if pipeline.os.name != "posix":

--- a/scripts/test_release_tools.py
+++ b/scripts/test_release_tools.py
@@ -390,9 +390,21 @@ class ReleaseToolTests(unittest.TestCase):
         self.assertIn("environment: crates-io", publication)
         self.assertIn("artifact-ids: ${{ needs.verify.outputs.artifact_id }}", publication)
         self.assertIn("digest-mismatch: error", publication)
-        compare = publication.index('cmp "target/package/rxls-${version}.crate"')
+        compare = publication.index('python3 scripts/core_release_handoff.py verify')
         self.assertLess(compare, publication.index("name: Publish to crates.io"))
         self.assertIn('"$smoke/assets/wasm-native-report.json"', publication)
+
+    def test_manual_rehearsal_transfers_the_real_publication_bundle_without_secrets(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("      rehearse_publication:", workflow)
+        rehearsal = workflow.split("  rehearse:\n", 1)[1].split("  publish:\n", 1)[0]
+        self.assertIn("      contents: read", rehearsal)
+        self.assertNotIn("secrets.", rehearsal)
+        self.assertNotIn("environment:", rehearsal)
+        self.assertIn("artifact-ids: ${{ needs.verify.outputs.artifact_id }}", rehearsal)
+        self.assertIn("digest-mismatch: error", rehearsal)
+        self.assertIn("python3 scripts/core_release_handoff.py verify", rehearsal)
+        self.assertNotIn("cargo publish", rehearsal)
 
     def test_hosted_candidate_release_bundle_contract_is_exactly_48_files(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")

--- a/scripts/test_workflow_policy.py
+++ b/scripts/test_workflow_policy.py
@@ -617,12 +617,10 @@ steps:
             "artifact_output": ("artifact_id: ${{ steps.publication_bundle.outputs.artifact-id }}", "artifact_id: 1234"),
             "artifact_input": ("artifact-ids: ${{ needs.verify.outputs.artifact_id }}", "name: latest-release"),
             "artifact_digest_mode": ("digest-mismatch: error", "digest-mismatch: warn"),
-            "artifact_digest": ('"digest": f"sha256:{expected_digest}",', '"digest": artifact["digest"],'),
-            "artifact_run": ('"id": int(os.environ["GITHUB_RUN_ID"]),', '"id": 123,'),
-            "artifact_sha": ('"head_sha": os.environ["GITHUB_SHA"],', '"head_sha": "main",'),
-            "artifact_repository": ('"head_repository_id": int(os.environ["GITHUB_REPOSITORY_ID"]),', '"head_repository_id": 123,'),
-            "artifact_expired": ('"expired": False,', '"expired": True,'),
-            "archive_bytes": ('cmp "target/package/rxls-${version}.crate" "dist/rxls-${version}.crate"', "true"),
+            "artifact_digest": ('ARTIFACT_DIGEST: ${{ needs.verify.outputs.artifact_digest }}', 'ARTIFACT_DIGEST: guessed'),
+            "artifact_attempt": ('SOURCE_ATTEMPT: ${{ needs.verify.outputs.source_attempt }}', 'SOURCE_ATTEMPT: 1'),
+            "artifact_authentication": ('python3 scripts/core_release_handoff.py authenticate', "true"),
+            "archive_bytes": ('python3 scripts/core_release_handoff.py verify', "true"),
             "handoff_skip": ("      - name: Verify publication handoff and package bytes\n", "      - name: Verify publication handoff and package bytes\n        if: false\n"),
             "publish_after_failure": ("      - name: Publish to crates.io\n        if: github.event_name == 'push'", "      - name: Publish to crates.io\n        if: always() && github.event_name == 'push'"),
             "stale_version": ('--registry-version "$version"', "--registry-version 0.1.3"),
@@ -635,14 +633,15 @@ steps:
                 self.assertTrue(self.policy.audit_core_release_evidence(Path("release.yml"), mutated))
 
     def test_core_release_artifact_metadata_authentication(self) -> None:
-        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-        step = workflow.split("      - name: Authenticate verified publication artifact\n", 1)[1].split("      - name:", 1)[0]
-        script = textwrap.dedent(step.split("python3 - <<'PY'\n", 1)[1].rsplit("          PY", 1)[0])
+        spec = importlib.util.spec_from_file_location("core_release_handoff", ROOT / "scripts/core_release_handoff.py")
+        handoff = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(handoff)
         environment = {
             "ARTIFACT_ID": "456", "ARTIFACT_DIGEST": "a" * 64,
             "SOURCE_ATTEMPT": "1", "VERIFIED_VERSION": "0.1.4",
             "GITHUB_RUN_ID": "123", "GITHUB_RUN_ATTEMPT": "2",
             "GITHUB_SHA": "b" * 40, "GITHUB_REPOSITORY_ID": "789",
+            "GITHUB_REPOSITORY": "HyunjoJung/rxls",
         }
         metadata = {
             "id": 456, "name": f"rxls-0.1.4-publication-{'b' * 40}-123-1",
@@ -651,8 +650,7 @@ steps:
         }
 
         def authenticate(data, env):
-            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(Path, "read_text", return_value=json.dumps(data)):
-                exec(compile(script, "release-artifact-authentication", "exec"), {})
+            handoff.authenticate(data, env)
 
         # A publication-only rerun may reuse its successful verification job's
         # exact earlier attempt, never a name-selected latest artifact.
@@ -663,14 +661,51 @@ steps:
             ("name", metadata["name"].replace("-123-1", "-123-2")),
             ("digest", f"sha256:{'c' * 64}"), ("workflow_run", None),
         ):
-            with self.subTest(field=key, value=value), self.assertRaises(SystemExit):
+            with self.subTest(field=key, value=value), self.assertRaises(handoff.HandoffError):
                 authenticate({**metadata, key: value}, environment)
         for key in metadata["workflow_run"]:
-            with self.subTest(run_field=key), self.assertRaises(SystemExit):
+            with self.subTest(run_field=key), self.assertRaises(handoff.HandoffError):
                 authenticate({**metadata, "workflow_run": {**metadata["workflow_run"], key: "wrong"}}, environment)
         for key, value in (("SOURCE_ATTEMPT", "0"), ("SOURCE_ATTEMPT", "3"), ("ARTIFACT_DIGEST", "invalid")):
-            with self.subTest(environment=key), self.assertRaises(SystemExit):
+            with self.subTest(environment=key), self.assertRaises(handoff.HandoffError):
                 authenticate(metadata, {**environment, key: value})
+
+    def test_rehearsal_input_is_early_typed_and_cannot_enable_publication(self) -> None:
+        original = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        step = self.policy._yaml_blocks(original, "- name: Validate release identity", 6)[0]
+        script = self.policy._workflow_run_scripts("    steps:\n" + step)[0].split("version=$(python3", 1)[0]
+        base = {
+            "REQUEST_REHEARSAL": "true", "BASELINE_RUN_ID": "",
+            "GITHUB_EVENT_NAME": "workflow_dispatch",
+            "GITHUB_REPOSITORY": "HyunjoJung/rxls", "GITHUB_REF": "refs/heads/main",
+        }
+        for changes, expected in (
+            ({}, 0), ({"REQUEST_REHEARSAL": "false", "BASELINE_RUN_ID": "123"}, 0),
+            ({"BASELINE_RUN_ID": "123"}, 1), ({"REQUEST_REHEARSAL": '"true"'}, 1),
+            ({"REQUEST_REHEARSAL": "null"}, 1), ({"REQUEST_REHEARSAL": "true "}, 1),
+            ({"GITHUB_EVENT_NAME": "push"}, 1), ({"GITHUB_REF": "refs/heads/topic"}, 1),
+            ({"GITHUB_REPOSITORY": "other/rxls"}, 1),
+        ):
+            with self.subTest(input=changes):
+                result = subprocess.run(["bash", "-c", script], env={**os.environ, **base, **changes}, capture_output=True, timeout=5)
+                self.assertEqual(result.returncode, expected, result.stderr)
+        mutations = (
+            ("        default: false\n        type: boolean", "        default: true\n        type: boolean"),
+            ('test -z "$BASELINE_RUN_ID" || {', "true || {"),
+            ("github.event_name == 'push' || steps.release.outputs.rehearse == 'true'", "github.event_name == 'push'"),
+            ("    name: Rehearse publication handoff (read-only)", "    name: Rehearse publication handoff (read-only)\n    environment: crates-io"),
+            ("    name: Rehearse publication handoff (read-only)", "    name: Rehearse publication handoff (read-only)\n    env:\n      TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}"),
+            ("github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')", "inputs.rehearse_publication == true"),
+            ("      - name: Rehearse publication handoff and package bytes\n", "      - name: Rehearse publication handoff and package bytes\n        if: false\n"),
+            ("      - name: Validate rehearsal identity\n", "      - name: Validate rehearsal identity\n        if: false\n"),
+            ("      - name: Upload successful rehearsal receipt\n", "      - name: Upload successful rehearsal receipt\n        if: always()\n"),
+            ("          digest-mismatch: error", "          digest-mismatch: warn"),
+        )
+        for old, new in mutations:
+            with self.subTest(mutation=old):
+                modified = original.replace(old, new, 1)
+                self.assertNotEqual(modified, original)
+                self.assertTrue(self.policy.audit_core_release_evidence(Path("release.yml"), modified))
 
     def test_github_release_reconciler_invariants_are_mutation_guarded(self) -> None:
         path = Path("scripts/reconcile_github_release.py")
@@ -3990,6 +4025,23 @@ steps:
                         Path("wasm-package-release.yml"), workflow
                     )
                 self.assertTrue(errors)
+
+    def test_shared_core_handoff_is_review_bound(self) -> None:
+        path = Path("scripts/core_release_handoff.py")
+        original = (ROOT / path).read_text(encoding="utf-8")
+        self.assertEqual(self.policy.audit_core_handoff_helper(path, original), [])
+        for old, new in (
+            ('"expired": False', '"expired": True'),
+            ('"head_repository_id": repository_id', '"head_repository_id": 1'),
+            ('"--expected-files", "52"', '"--expected-files", "48"'),
+            ('require(actual == expected,', 'require(True,'),
+            ('["cargo", "package", "--locked"]', '["cargo", "publish", "--locked"]'),
+            ('timeout=COMMAND_TIMEOUT', 'timeout=None'),
+        ):
+            with self.subTest(mutation=old):
+                modified = original.replace(old, new, 1)
+                self.assertNotEqual(modified, original)
+                self.assertTrue(self.policy.audit_core_handoff_helper(path, modified))
 
     def test_checked_in_codeql_explicitly_builds_every_rust_surface(self) -> None:
         text = CODEQL_WORKFLOW.read_text(encoding="utf-8")

--- a/src/spreadsheet/cell_edit.rs
+++ b/src/spreadsheet/cell_edit.rs
@@ -13,6 +13,73 @@ use std::collections::{BTreeMap, BTreeSet};
 const MAX_EDIT_RANGE_CELLS: u64 = 10_000;
 
 impl Spreadsheet {
+    /// Replace a nonempty rectangular cell range in one package transaction.
+    ///
+    /// The range starts at the zero-based row and column. `Some` writes a typed
+    /// value; `None` clears only value/formula content, retaining cell metadata.
+    /// At most 10,000 cells and 1 MiB of aggregate UTF-8 text are accepted. Ragged
+    /// rows, invalid values, grid overflow, ambiguous targets, and merged-cell
+    /// interiors are rejected without changing the package. Shared or array
+    /// formula groups may only be replaced in their entirety. Formula values must
+    /// carry explicit caches; this method does not evaluate formulas. Styles,
+    /// unrelated parts, and the parsed workbook view are preserved.
+    pub fn set_cell_range_values(
+        &mut self,
+        sheet_name: &str,
+        start_row: u32,
+        start_col: u16,
+        values: &[Vec<Option<Cell>>],
+    ) -> Result<()> {
+        self.ensure_editable()?;
+        let columns = values.first().map_or(0, Vec::len);
+        if columns == 0
+            || values.len().saturating_mul(columns) as u64 > MAX_EDIT_RANGE_CELLS
+            || values.iter().any(|row| row.len() != columns)
+        {
+            return Err(Error::Zip(
+                "cell range must be rectangular and contain 1 to 10000 cells",
+            ));
+        }
+        let last_row = u64::from(start_row) + values.len() as u64 - 1;
+        let last_col = u64::from(start_col) + columns as u64 - 1;
+        if last_row > 1_048_575 || last_col > 16_383 {
+            return Err(Error::Zip("cell range is outside the Excel grid"));
+        }
+        let mut text_bytes = 0_usize;
+        for value in values.iter().flatten().flatten() {
+            validate_edit_cell_value(value)?;
+            text_bytes = text_bytes.saturating_add(edit_value_text_bytes(value));
+            if text_bytes > 1 << 20 {
+                return Err(Error::Zip("cell range text exceeds 1 MiB"));
+            }
+        }
+        let package = self.package.as_ref().ok_or(Error::MissingWorkbook)?;
+        let mut names = BTreeSet::new();
+        for name in &self.workbook.sheets {
+            if !names.insert(name.name.to_ascii_lowercase()) {
+                return Err(Error::Zip("cell range requires unambiguous sheet names"));
+            }
+        }
+        let path = worksheet_path(package, sheet_name)?;
+        let range = (start_row, start_col, last_row as u32, last_col as u16);
+        peek_part_tree(package, &path, Error::MissingWorkbook, |tree| {
+            validate_range_targets(tree, range)
+        })?;
+        self.mutate_atomic(|candidate| {
+            let package = candidate.package.as_mut().ok_or(Error::MissingWorkbook)?;
+            let before = package.touched_parts();
+            let tree = package.part_tree_mut(&path)?;
+            sml_edit_cell_range(tree, start_row, start_col, values)?;
+            for part in newly_touched(&before, package) {
+                remember_edited_part(&mut candidate.edited_parts, part);
+            }
+            for part in invalidate_calc_chain(package)? {
+                remember_edited_part(&mut candidate.edited_parts, part);
+            }
+            Ok(())
+        })
+    }
+
     /// Set a worksheet cell in the retained OOXML package.
     ///
     /// The parsed [`crate::Workbook`] view is intentionally not mutated; reopen the
@@ -342,6 +409,196 @@ fn validate_formula_cached_value(value: &Cell) -> Result<()> {
         )),
         Cell::Number(_) | Cell::Date(_) | Cell::Bool(_) => Ok(()),
     }
+}
+
+fn edit_value_text_bytes(value: &Cell) -> usize {
+    match value {
+        Cell::Text(text) | Cell::Error(text) => text.len(),
+        Cell::Formula { formula, cached } => {
+            formula.len().saturating_add(edit_value_text_bytes(cached))
+        }
+        _ => 0,
+    }
+}
+
+fn validate_range_targets(tree: &XmlTree, range: (u32, u16, u32, u16)) -> Result<()> {
+    let root = tree.root_element().ok_or(Error::MissingWorkbook)?;
+    if let Some(merges) = tree.child_by_name(root, b"mergeCells") {
+        for &merge in tree.children_of(merges) {
+            let (r0, c0, r1, c1) = tree
+                .attr_value(merge, b"ref")
+                .and_then(|value| std::str::from_utf8(value).ok())
+                .and_then(super::selection::parse_a1_range)
+                .ok_or(Error::Zip(
+                    "cell range cannot edit malformed merged metadata",
+                ))?;
+            let first_row = r0.max(range.0);
+            let first_col = c0.max(range.1);
+            let last_row = r1.min(range.2);
+            let last_col = c1.min(range.3);
+            if first_row <= last_row
+                && first_col <= last_col
+                && (first_row != r0 || first_col != c0 || last_row != r0 || last_col != c0)
+            {
+                return Err(Error::Zip("cell range includes a merged-cell interior"));
+            }
+        }
+    }
+    let mut targets = BTreeSet::new();
+    let mut target_rows = BTreeSet::new();
+    if let Some(data) = tree.child_by_name(root, b"sheetData") {
+        for &row in tree.children_of(data) {
+            let source_row = sml_row_ref(tree, row);
+            if let Some(index) = source_row.and_then(|row| row.checked_sub(1)) {
+                if index >= range.0 && index <= range.2 && !target_rows.insert(index) {
+                    return Err(Error::Zip("cell range contains an ambiguous source row"));
+                }
+            }
+            for &cell in tree.children_of(row) {
+                if let Some(coordinate) = tree
+                    .attr_value(cell, b"r")
+                    .and_then(|value| std::str::from_utf8(value).ok())
+                    .and_then(super::selection::parse_a1_cell)
+                {
+                    if coordinate.0 >= range.0
+                        && coordinate.0 <= range.2
+                        && coordinate.1 >= range.1
+                        && coordinate.1 <= range.3
+                        && (source_row != Some(coordinate.0 + 1) || !targets.insert(coordinate))
+                    {
+                        return Err(Error::Zip("cell range contains an ambiguous source target"));
+                    }
+                }
+                if let Some(formula) = tree.child_by_name(cell, b"f") {
+                    if matches!(tree.attr_value(formula, b"t"), Some(b"shared" | b"array")) {
+                        if let Some(reference) = tree.attr_value(formula, b"ref") {
+                            let grouped = std::str::from_utf8(reference)
+                                .ok()
+                                .and_then(super::selection::parse_a1_range)
+                                .ok_or(Error::Zip(
+                                    "cell range cannot edit malformed formula metadata",
+                                ))?;
+                            if super::selection::ranges_overlap(range, grouped)
+                                && !(range.0 <= grouped.0
+                                    && range.1 <= grouped.1
+                                    && range.2 >= grouped.2
+                                    && range.3 >= grouped.3)
+                            {
+                                return Err(Error::Zip(
+                                    "cell range cannot partially replace a shared or array formula",
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn sml_edit_cell_range(
+    tree: &mut XmlTree,
+    start_row: u32,
+    start_col: u16,
+    values: &[Vec<Option<Cell>>],
+) -> Result<()> {
+    let data = sml_sheet_data(tree)?;
+    let (rows, row_positions) = range_node_plan(tree, data, start_row, values.len(), |node| {
+        sml_row_ref(tree, node)?
+            .checked_sub(1)
+            .map(|row| (row, true))
+    });
+    let mut inserted_rows = 0;
+    for (row_offset, values) in values.iter().enumerate() {
+        let row = start_row + row_offset as u32;
+        let row_node = match rows[row_offset] {
+            Some(node) => node,
+            None if values.iter().all(Option::is_none) => continue,
+            None => {
+                let fragment = format!(r#"<row r="{}"></row>"#, row + 1);
+                let node = tree.insert_fragment_at(
+                    data,
+                    row_positions[row_offset + 1] + inserted_rows,
+                    fragment.as_bytes(),
+                )?;
+                inserted_rows += 1;
+                node
+            }
+        };
+        let (cells, cell_positions) =
+            range_node_plan(tree, row_node, u32::from(start_col), values.len(), |node| {
+                let reference = tree.attr_value(node, b"r")?;
+                let col = sml_col_of_ref(reference)?;
+                let exact = std::str::from_utf8(reference)
+                    .ok()
+                    .and_then(super::selection::parse_a1_cell)
+                    .is_some_and(|(cell_row, cell_col)| {
+                        cell_row == row && u32::from(cell_col) == col
+                    });
+                Some((col, exact))
+            });
+        let mut inserted_cells = 0;
+        for (offset, value) in values.iter().enumerate() {
+            let col = start_col + offset as u16;
+            let cell = match (cells[offset], value) {
+                (Some(cell), _) => cell,
+                (None, None) => continue,
+                (None, Some(_)) => {
+                    let fragment = format!(r#"<c r="{}"></c>"#, a1(row, col));
+                    let node = tree.insert_fragment_at(
+                        row_node,
+                        cell_positions[offset + 1] + inserted_cells,
+                        fragment.as_bytes(),
+                    )?;
+                    inserted_cells += 1;
+                    node
+                }
+            };
+            if let Some(value) = value {
+                sml_set_cell_value(tree, cell, value)?;
+            } else {
+                for name in [b"v".as_slice(), b"f".as_slice(), b"is".as_slice()] {
+                    while let Some(child) = tree.child_by_name(cell, name) {
+                        tree.remove_child(cell, child)?;
+                    }
+                }
+                tree.remove_attr(cell, b"t");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Index only the bounded target span, retaining document-order insertion
+/// semantics even when source siblings are unsorted. Suffix minima locate the
+/// first original sibling above each target; increasing target coordinates then
+/// require only a running count of prior insertions, not repeated source scans.
+fn range_node_plan(
+    tree: &XmlTree,
+    parent: NodeId,
+    start: u32,
+    count: usize,
+    coordinate: impl Fn(NodeId) -> Option<(u32, bool)>,
+) -> (Vec<Option<NodeId>>, Vec<usize>) {
+    let children = tree.children_of(parent);
+    let mut nodes = vec![None; count];
+    let mut positions = vec![children.len(); count + 1];
+    for (position, &node) in children.iter().enumerate() {
+        if let Some((key, exact)) = coordinate(node) {
+            if let Some(offset) = key.checked_sub(start) {
+                let offset = (offset as usize).min(count);
+                positions[offset] = positions[offset].min(position);
+                if exact && offset < count {
+                    nodes[offset] = Some(node);
+                }
+            }
+        }
+    }
+    for offset in (0..count).rev() {
+        positions[offset] = positions[offset].min(positions[offset + 1]);
+    }
+    (nodes, positions)
 }
 
 fn validate_edit_cell_value(value: &Cell) -> Result<()> {

--- a/src/spreadsheet/tests.rs
+++ b/src/spreadsheet/tests.rs
@@ -527,6 +527,197 @@ fn cell_update_batch_preserves_shared_and_array_formula_nodes_and_cell_metadata(
 }
 
 #[test]
+fn rectangular_cell_values_write_and_clear_in_one_preserving_transaction() {
+    let mut spreadsheet = Spreadsheet::open(&minimal_xlsx_with_worksheet(
+        STYLED_WORKSHEET_XML,
+        MINIMAL_CONTENT_TYPES_XML,
+    ))
+    .unwrap();
+    spreadsheet
+        .set_cell_range_values(
+            "Data",
+            0,
+            0,
+            &[
+                vec![None, Some(Cell::Number(7.0))],
+                vec![Some(Cell::Text("new".into())), Some(Cell::Bool(true))],
+            ],
+        )
+        .unwrap();
+    let saved = spreadsheet.save().unwrap();
+    let reopened = Workbook::open(&saved).unwrap();
+    assert_eq!(reopened.sheets[0].cell(0, 0), None);
+    assert_eq!(reopened.sheets[0].cell(0, 1), Some(&Cell::Number(7.0)));
+    assert_eq!(
+        reopened.sheets[0].cell(1, 0),
+        Some(&Cell::Text("new".into()))
+    );
+    let xml = String::from_utf8(
+        super::part_xml_bytes(
+            spreadsheet.package.as_ref().unwrap(),
+            "xl/worksheets/sheet1.xml",
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(xml.contains("s=\"3\""));
+    assert_eq!(spreadsheet.edited_parts(), ["xl/worksheets/sheet1.xml"]);
+}
+
+#[test]
+fn rectangular_cell_values_reject_invalid_batches_without_partial_mutation() {
+    let input = minimal_xlsx_with_worksheet(MINIMAL_WORKSHEET_XML, MINIMAL_CONTENT_TYPES_XML);
+    let mut spreadsheet = Spreadsheet::open(&input).unwrap();
+    let original = spreadsheet.save().unwrap();
+    for values in [
+        vec![],
+        vec![vec![]],
+        vec![vec![None], vec![]],
+        vec![vec![Some(Cell::Number(4.0)), Some(Cell::Number(f64::NAN))]],
+        vec![vec![
+            Some(Cell::Number(4.0)),
+            Some(Cell::Text("bad\0xml".into())),
+        ]],
+        vec![vec![None; 101]; 100],
+        vec![vec![Some(Cell::Text("x".repeat(32767))); 33]],
+    ] {
+        assert!(spreadsheet
+            .set_cell_range_values("Data", 0, 0, &values)
+            .is_err());
+        assert_rejected_edit_is_unchanged(&spreadsheet, &original);
+    }
+    assert!(spreadsheet
+        .set_cell_range_values("Data", 1_048_575, 0, &[vec![None], vec![None]])
+        .is_err());
+    assert!(spreadsheet
+        .set_cell_range_values("Data", 0, 16_383, &[vec![None, None]])
+        .is_err());
+    assert_rejected_edit_is_unchanged(&spreadsheet, &original);
+    let mut broken = Spreadsheet::open(&minimal_xlsx_with_worksheet(
+        MINIMAL_WORKSHEET_XML,
+        UNTYPED_WORKSHEET_CONTENT_TYPES_XML,
+    ))
+    .unwrap();
+    let original = broken.save().unwrap();
+    assert!(broken
+        .set_cell_range_values(
+            "Data",
+            0,
+            0,
+            &[vec![Some(Cell::Number(8.0)), Some(Cell::Bool(false))]]
+        )
+        .is_err());
+    assert_rejected_edit_is_unchanged(&broken, &original);
+}
+
+#[test]
+fn rectangular_cell_values_reject_ambiguous_targets_and_partial_formula_groups() {
+    for data in [
+        r#"<row r="2"><c r="A1"><v>1</v></c></row>"#,
+        r#"<row r="1"><c r="A1"><v>1</v></c></row><row r="1"><c r="B1"><v>2</v></c></row>"#,
+        r#"<row r="1"><c r="A1"><v>1</v></c><c r="A1"><v>2</v></c></row>"#,
+        r#"<row r="1"><c r="A1"><f t="shared" si="0" ref="A1:B1">1+1</f><v>2</v></c><c r="B1"><f t="shared" si="0"/><v>2</v></c></row>"#,
+        r#"<row r="1"><c r="A1"><f t="array" ref="A1:B1">1+1</f><v>2</v></c><c r="B1"><v>2</v></c></row>"#,
+    ] {
+        let worksheet = format!(
+            r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>{data}</sheetData></worksheet>"#
+        );
+        let mut spreadsheet = Spreadsheet::open(&minimal_xlsx_with_worksheet(
+            worksheet.as_bytes(),
+            MINIMAL_CONTENT_TYPES_XML,
+        ))
+        .unwrap();
+        let before = spreadsheet.save().unwrap();
+        assert!(
+            spreadsheet
+                .set_cell_range_values("Data", 0, 0, &[vec![Some(Cell::Number(9.0))]])
+                .is_err(),
+            "{data}"
+        );
+        assert_rejected_edit_is_unchanged(&spreadsheet, &before);
+    }
+}
+
+#[test]
+fn rectangular_cell_values_match_sequential_writes_with_unsorted_siblings() {
+    for (start_row, start_col) in [(0, 0), (1, 1), (4, 4)] {
+        let worksheet = br#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="5"><c r="E5"><v>5</v></c><c r="A5" s="3"><v>1</v></c></row><row r="1"><c r="E1"><v>5</v></c><c r="C1"><v>3</v></c><c r="A1" s="3"><v>1</v></c></row><row r="3"><c r="C3"><v>3</v></c><c r="A3"><v>1</v></c></row></sheetData></worksheet>"#;
+        let input = minimal_xlsx_with_worksheet(worksheet, MINIMAL_CONTENT_TYPES_XML);
+        let mut batch = Spreadsheet::open(&input).unwrap();
+        let mut sequential = Spreadsheet::open(&input).unwrap();
+        let values = vec![vec![Some(Cell::Number(9.0)); 4]; 4];
+        for row in start_row..start_row + 4 {
+            for col in start_col..start_col + 4 {
+                sequential
+                    .set_cell_value("Data", row, col, Cell::Number(9.0))
+                    .unwrap();
+            }
+        }
+        batch
+            .set_cell_range_values("Data", start_row, start_col, &values)
+            .unwrap();
+        assert_eq!(batch.save().unwrap(), sequential.save().unwrap());
+    }
+}
+
+#[test]
+fn rectangular_cell_values_roll_back_a_late_tree_budget_failure() {
+    let input = minimal_xlsx_with_one_valued_cell();
+    let mut spreadsheet = Spreadsheet::open(&input).unwrap();
+    let before = spreadsheet.save().unwrap();
+    // Enough room for the first replacement, but not a newly inserted second
+    // row. The transaction must roll back the earlier successful value write.
+    let nodes = XmlTree::parse(MINIMAL_WORKSHEET_XML).unwrap().node_count();
+    set_test_node_budget(nodes + 2);
+    let result = spreadsheet.set_cell_range_values(
+        "Data",
+        0,
+        0,
+        &[vec![Some(Cell::Number(7.0))], vec![Some(Cell::Number(8.0))]],
+    );
+    reset_test_node_budget();
+    assert!(result.is_err());
+    assert_rejected_edit_is_unchanged(&spreadsheet, &before);
+}
+
+#[test]
+fn rectangular_cell_values_preserve_all_untouched_macro_package_parts() {
+    let mut package =
+        crate::package::Package::from_bytes(&minimal_xlsx_with_one_valued_cell()).unwrap();
+    package.ensure_content_type(
+        "xl/workbook.xml",
+        "application/vnd.ms-excel.sheet.macroEnabled.main+xml",
+    );
+    package.set_part(
+        "xl/vbaProject.bin",
+        b"\0\x01synthetic macro payload\xff".to_vec(),
+        Some("application/vnd.ms-office.vbaProject"),
+    );
+    let before = package.to_bytes().unwrap();
+    let package = crate::package::Package::from_bytes(&before).unwrap();
+    let mut spreadsheet = Spreadsheet::open(&before).unwrap();
+    spreadsheet
+        .set_cell_range_values(
+            "Data",
+            0,
+            0,
+            &[
+                vec![Some(Cell::Number(7.0)), Some(Cell::Bool(true))],
+                vec![None, Some(Cell::Text("replacement".into()))],
+            ],
+        )
+        .unwrap();
+    let saved = spreadsheet.save().unwrap();
+    let after = crate::package::Package::from_bytes(&saved).unwrap();
+    for name in package
+        .part_names()
+        .filter(|name| *name != "xl/worksheets/sheet1.xml")
+    {
+        assert_eq!(after.part_bytes(name), package.part_bytes(name), "{name}");
+    }
+}
+
+#[test]
 fn defined_name_validation_rejects_invalid_or_colliding_names_without_mutation() {
     let mut workbook = Workbook::new();
     workbook.add_sheet("Data").write(0, 0, 1.0);

--- a/tests/oracles/public-api-main.json
+++ b/tests/oracles/public-api-main.json
@@ -2083,6 +2083,7 @@
         "pub fn save_to_path(&self, path: impl AsRef<Path>) -> Result<()>",
         "pub fn set_active_sheet(&mut self, sheet_name: &str) -> Result<()>",
         "pub fn set_cell_formula( &mut self, sheet_name: &str, row: u32, col: u16, formula: impl AsRef<str>, cached: impl Into<Cell>, ) -> Result<()>",
+        "pub fn set_cell_range_values( &mut self, sheet_name: &str, start_row: u32, start_col: u16, values: &[Vec<Option<Cell>>], ) -> Result<()>",
         "pub fn set_cell_value( &mut self, sheet_name: &str, row: u32, col: u16, value: Cell, ) -> Result<()>",
         "pub fn set_column_hidden( &mut self, sheet_name: &str, col: u16, hidden: bool, ) -> Result<()>",
         "pub fn set_column_width( &mut self, sheet_name: &str, col: u16, width: f32, ) -> Result<()>",

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -10,12 +10,23 @@ and ODS stay read-only.
 
 In the current source build, click a rendered cell once in editable sheet view
 to edit it directly,
-or edit its value in the formula bar. Enter commits and moves down; Tab commits
+or use the formula bar's Edit cell control. Enter commits and moves down; Tab commits
 and moves across; Escape cancels the draft. Tab at the last cell and Shift+Tab
 at the first cell leave the worksheet after any draft is successfully saved.
 A leading `=` enters a formula.
 The typed-cell dialog remains available for explicit value kinds and cached
 formula values.
+
+Paste tab-separated cells into the selected cell to preview a rectangular range
+before applying it. Quoted tabs, line breaks, and blank cells are preserved.
+One undo restores the entire paste, including recalculated formula caches.
+Paste is limited to 10,000 cells and a 1 MiB request; merged-cell interiors and
+unsupported new formulas reject the whole range. Formula references are used as
+written, without relative-reference translation. The preview also offers an
+explicit single-text-cell option for intentional multiline text.
+
+Unapplied Cell Options and Properties fields are protected when opening another
+file or leaving the page. Apply or cancel those fields before saving a copy.
 
 Committed edits refresh formulas supported by the deterministic evaluator in
 the same undo step. Unsupported formulas keep their cached values and produce
@@ -51,6 +62,12 @@ npm --prefix viewer run test:browser
 Set `RXLS_CHROMIUM_EXECUTABLE` when the browser test should use a specific
 Chrome or Chromium binary. Set `RXLS_VIEWER_SCREENSHOTS=1` to write desktop and
 mobile captures under `target/viewer-e2e/`.
+
+For a repeatable local navigation diagnostic, run
+`node viewer/scripts/benchmark-grid.mjs` from the repository root. Add
+`--baseline-ref <git-ref>` to compare an earlier grid implementation with the
+same harness. This isolates selection and keyboard navigation at up to 250,000
+rendered anchors; it does not measure browser rendering or worker execution.
 
 ## Runtime boundaries
 

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -357,11 +357,12 @@
             <label class="visually-hidden" for="inspector-value"
               >Cell value or formula</label
             >
-            <input
+            <textarea
               id="inspector-value"
+              rows="1"
               readonly
               placeholder="Enter a cell address to inspect its value or formula"
-            />
+            ></textarea>
             <span id="inspector-kind" class="inspector-kind"></span>
             <button
               id="inspector-edit"
@@ -436,9 +437,9 @@
               replace it. Enter applies an edit, Tab moves to the next cell, and
               Escape cancels. At the last cell, Tab leaves the worksheet;
               Shift+Tab at the first cell moves back to the preceding control.
-              Prefix text with an apostrophe to keep it as text.
-              Dates use Excel serial values. Formula calculation supports a
-              limited deterministic subset.
+              Prefix text with an apostrophe to keep it as text. Dates use Excel
+              serial values. Formula calculation supports a limited
+              deterministic subset.
             </p>
             <span
               id="grid-status"
@@ -768,6 +769,46 @@
           </button>
         </footer>
       </form>
+    </dialog>
+
+    <dialog
+      id="paste-dialog"
+      class="edit-dialog"
+      aria-labelledby="paste-title"
+      aria-describedby="paste-status"
+    >
+      <div class="edit-form paste-form">
+        <header class="dialog-header">
+          <div>
+            <h2 id="paste-title">Paste cells</h2>
+            <p id="paste-summary"></p>
+          </div>
+        </header>
+        <div class="paste-preview-container">
+          <table
+            class="paste-preview"
+            aria-label="Clipboard preview, first five rows and columns"
+          >
+            <tbody id="paste-preview"></tbody>
+          </table>
+        </div>
+        <p id="paste-status" class="dialog-status" aria-live="polite"></p>
+        <footer class="dialog-actions">
+          <button id="cancel-range-paste" class="command-button" type="button">
+            Cancel
+          </button>
+          <button id="paste-as-text" class="command-button" type="button">
+            Paste as one text cell
+          </button>
+          <button
+            id="apply-range-paste"
+            class="command-button primary"
+            type="button"
+          >
+            Apply range
+          </button>
+        </footer>
+      </div>
     </dialog>
 
     <script type="module" src="/src/main.js"></script>

--- a/viewer/scripts/benchmark-grid.mjs
+++ b/viewer/scripts/benchmark-grid.mjs
@@ -1,0 +1,94 @@
+import { execFileSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import { createGridEditor } from "../src/grid-editor.js";
+import { setup, flush } from "../tests/support/grid-editor.mjs";
+
+// Local diagnostic, not a wall-clock CI assertion. Worker/DOM rendering time is excluded.
+const args = process.argv.slice(2);
+if (
+  args.length &&
+  (args.length !== 2 ||
+    args[0] !== "--baseline-ref" ||
+    !/^[a-zA-Z0-9._/-]+$/.test(args[1]))
+)
+  throw new Error(
+    "Usage: node scripts/benchmark-grid.mjs [--baseline-ref <git-ref>]",
+  );
+let createEditor = createGridEditor;
+if (args.length) {
+  const source = execFileSync(
+    "git",
+    ["show", `${args[1]}:viewer/src/grid-editor.js`],
+    {
+      cwd: fileURLToPath(new URL("../../", import.meta.url)),
+      encoding: "utf8",
+    },
+  ).replace(
+    '"./core.js"',
+    JSON.stringify(new URL("../src/core.js", import.meta.url).href),
+  );
+  ({ createGridEditor: createEditor } = await import(
+    `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+  ));
+}
+const results = [];
+const percentile = (values, proportion) =>
+  [...values].sort((a, b) => a - b)[
+    Math.min(values.length - 1, Math.floor(values.length * proportion))
+  ];
+for (const count of [1_000, 10_000, 100_000, 250_000]) {
+  const cells = Array.from({ length: count }, (_, i) => [
+    Math.floor(i / 100),
+    i % 100,
+    (i % 100) * 50,
+    Math.floor(i / 100) * 20,
+    50,
+    20,
+  ]);
+  const env = setup({ createEditor });
+  const start = performance.now();
+  env.grid.mount(
+    {
+      schemaVersion: 1,
+      width: 5000,
+      height: Math.ceil(count / 100) * 20,
+      cells,
+    },
+    env.svg,
+  );
+  const mountMs = performance.now() - start;
+  await flush();
+  await env.grid.select(Math.floor(count / 200), 50);
+  const arrowMs = [];
+  const tabMs = [];
+  for (let i = 0; i < 70; i++) {
+    let began = performance.now();
+    await env.input.fire("keydown", { key: i % 2 ? "ArrowUp" : "ArrowDown" });
+    if (i >= 10) arrowMs.push(performance.now() - began);
+    began = performance.now();
+    await env.input.fire("keydown", { key: "Tab", shiftKey: Boolean(i % 2) });
+    if (i >= 10) tabMs.push(performance.now() - began);
+  }
+  results.push({
+    cells: count,
+    mountMs,
+    arrowMedianMs: percentile(arrowMs, 0.5),
+    arrowP95Ms: percentile(arrowMs, 0.95),
+    tabMedianMs: percentile(tabMs, 0.5),
+    tabP95Ms: percentile(tabMs, 0.95),
+  });
+}
+console.log(
+  JSON.stringify(
+    {
+      schemaVersion: 1,
+      node: process.version,
+      source: args[1] ?? "working-tree",
+      samples: 60,
+      results,
+    },
+    null,
+    2,
+  ),
+);

--- a/viewer/src/clipboard.js
+++ b/viewer/src/clipboard.js
@@ -1,0 +1,120 @@
+import { gridCellReference, inlineCellValue } from "./grid-editor.js";
+
+export const MAX_PASTE_BYTES = 1024 * 1024;
+export const MAX_PASTE_CELLS = 10_000;
+const encoder = new TextEncoder();
+
+function checkSize(text) {
+  if (
+    text.length > MAX_PASTE_BYTES ||
+    encoder.encode(text).length > MAX_PASTE_BYTES
+  )
+    throw new RangeError("Clipboard size exceeds the 1 MiB paste limit.");
+}
+
+/** Decode spreadsheet TSV without interpreting HTML or requesting clipboard access. */
+export function parseClipboardRange(text) {
+  if (typeof text !== "string" || !text.length)
+    throw new Error("The clipboard is empty.");
+  checkSize(text);
+  const rows = [];
+  let row = [];
+  let value = "";
+  let quoted = false;
+  let closed = false;
+  let fieldStart = true;
+  let cellCount = 0;
+  const field = () => {
+    if (++cellCount > MAX_PASTE_CELLS)
+      throw new RangeError("Paste is limited to 10,000 cells.");
+    row.push(value);
+    value = "";
+    closed = false;
+    fieldStart = true;
+  };
+  const record = () => {
+    field();
+    if (rows.length && row.length !== rows[0].length)
+      throw new Error("The clipboard must contain a rectangular range.");
+    rows.push(row);
+    row = [];
+  };
+  let endedRecord = false;
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    endedRecord = false;
+    if (quoted) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          value += '"';
+          i++;
+        } else {
+          quoted = false;
+          closed = true;
+        }
+      } else if (char === "\r") {
+        if (text[i + 1] === "\n") i++;
+        value += "\n";
+      } else value += char;
+    } else if (char === "\t") field();
+    else if (char === "\n" || char === "\r") {
+      if (char === "\r" && text[i + 1] === "\n") i++;
+      record();
+      endedRecord = true;
+    } else if (closed)
+      throw new Error("Unexpected text after a clipboard quote.");
+    else if (fieldStart && char === '"') {
+      quoted = true;
+      fieldStart = false;
+    } else {
+      value += char;
+      fieldStart = false;
+    }
+  }
+  if (quoted) throw new Error("The clipboard contains an unclosed quote.");
+  if (!endedRecord) record();
+  return rows;
+}
+
+/** Build a bounded typed transaction; a single-text fallback is always explicit. */
+export function rangePasteRequest(
+  text,
+  row,
+  col,
+  { asText = false, sheetIndex = 0 } = {},
+) {
+  if (typeof text !== "string" || !text.length)
+    throw new Error("The clipboard is empty.");
+  checkSize(text);
+  const rows = asText
+    ? [[text.replace(/\r\n?/g, "\n")]]
+    : parseClipboardRange(text);
+  if (
+    !Number.isInteger(row) ||
+    !Number.isInteger(col) ||
+    row < 0 ||
+    col < 0 ||
+    row + rows.length > 1_048_576 ||
+    col + rows[0].length > 16_384
+  )
+    throw new RangeError("The pasted range exceeds the worksheet boundaries.");
+  const values = rows.map((items) =>
+    items.map((value) =>
+      asText ? { kind: "text", value } : inlineCellValue(value),
+    ),
+  );
+  checkSize(
+    JSON.stringify({ sheetIndex, startRow: row, startCol: col, values }),
+  );
+  const start = gridCellReference(row, col);
+  const end = gridCellReference(
+    row + rows.length - 1,
+    col + rows[0].length - 1,
+  );
+  return {
+    rows,
+    values,
+    cellCount: rows.length * rows[0].length,
+    reference: start === end ? start : `${start}:${end}`,
+  };
+}

--- a/viewer/src/editing.js
+++ b/viewer/src/editing.js
@@ -25,7 +25,11 @@ export function createEditingController({
   confirm = (message) => globalThis.confirm(message),
 }) {
   const cellReads = createLatestRequestGate();
-  let mutationPending = false;
+  let mutationPending = null;
+  let cellBaseline = null;
+  let propertiesBaseline = null;
+  let cellDialogGeneration = 0;
+  let propertiesDialogGeneration = 0;
   let recalculationWarning = "";
   let warningContext = null;
   let warningSummary = null;
@@ -49,6 +53,9 @@ export function createEditingController({
     applyHistoryEdit,
     saveWorkbookCopy,
     commitCellEdit,
+    commitRangeEdit,
+    hasDraftChanges,
+    hasPendingMutation,
     confirmDiscardChanges,
   };
 
@@ -75,6 +82,10 @@ export function createEditingController({
     );
     elements["close-cell-dialog"].addEventListener("click", closeCellEditor);
     elements["cancel-cell-edit"].addEventListener("click", closeCellEditor);
+    elements["cell-dialog"].addEventListener("cancel", (event) => {
+      event.preventDefault();
+      if (!editing.cellEditPending) closeCellEditor();
+    });
     elements["read-cell"].addEventListener(
       "click",
       () => void loadCellIntoEditor(),
@@ -97,6 +108,10 @@ export function createEditingController({
       "click",
       closePropertiesEditor,
     );
+    elements["properties-dialog"].addEventListener("cancel", (event) => {
+      event.preventDefault();
+      if (!hasPendingMutation()) closePropertiesEditor();
+    });
     elements["properties-form"].addEventListener(
       "submit",
       (event) => void submitPropertiesEdit(event),
@@ -164,16 +179,21 @@ export function createEditingController({
   }
 
   async function openCellEditor() {
-    if (state.busy || mutationPending) return;
+    if (state.busy || hasPendingMutation()) return;
+    const target = currentTarget();
     if (beforeCommand && !(await beforeCommand())) return;
-    if (!canEditWorkbook()) {
+    if (!isCurrentTarget(target) || !canEditWorkbook()) {
       return;
     }
+    if (elements["cell-dialog"].open) return;
     elements["cell-sheet-name"].textContent =
       state.workbook.sheets[state.sheetIndex].name;
     if (!elements["cell-dialog"].open) {
       elements["cell-dialog"].showModal();
     }
+    cellDialogGeneration++;
+    resetCellEditorFields();
+    cellBaseline = snapshot(cellFields());
     invalidateCellRead();
     elements["cell-reference"].focus();
     elements["cell-reference"].select();
@@ -181,6 +201,8 @@ export function createEditingController({
   }
 
   function closeCellEditor() {
+    cellDialogGeneration++;
+    cellBaseline = null;
     cellReads.invalidate();
     editing.cellReadTarget = null;
     editing.cellReadPending = false;
@@ -194,9 +216,7 @@ export function createEditingController({
 
   function invalidateCellRead() {
     cellReads.invalidate();
-    editing.cellReadTarget = null;
     editing.cellReadPending = false;
-    resetCellEditorFields();
     if (elements["cell-dialog"].open) {
       elements["cell-current-value"].textContent =
         "Load this cell before editing it";
@@ -208,6 +228,14 @@ export function createEditingController({
     if (!canEditWorkbook()) {
       return;
     }
+    if (
+      changedSnapshot(cellBaseline, cellFields().slice(1)) &&
+      !confirm(
+        "Discard unapplied Cell Options changes before loading this cell?",
+      )
+    )
+      return;
+    const target = currentTarget();
     const token = cellReads.begin();
     const client = state.client;
     const documentId = state.documentId;
@@ -220,6 +248,7 @@ export function createEditingController({
     try {
       coordinate = parseCellReference(elements["cell-reference"].value);
       elements["cell-reference"].value = coordinate.normalized;
+      cellBaseline = snapshot(cellFields());
       elements["cell-current-value"].textContent =
         `Loading ${coordinate.normalized}`;
       const result = await client.readCell(
@@ -230,6 +259,7 @@ export function createEditingController({
       );
       if (
         !cellReads.isCurrent(token) ||
+        !isCurrentTarget(target) ||
         client !== state.client ||
         documentId !== state.documentId ||
         sheetIndex !== state.sheetIndex ||
@@ -245,11 +275,12 @@ export function createEditingController({
       );
       editing.cellReadPending = false;
       populateCellEditor(result.value);
+      cellBaseline = snapshot(cellFields());
       elements["cell-current-value"].textContent = result.formatted
         ? `${coordinate.normalized}: ${result.formatted}`
         : `${coordinate.normalized}: ${describeCell(result.value)}`;
     } catch (error) {
-      if (!cellReads.isCurrent(token)) {
+      if (!cellReads.isCurrent(token) || !isCurrentTarget(target)) {
         return;
       }
       editing.cellReadTarget = null;
@@ -257,7 +288,7 @@ export function createEditingController({
       elements["cell-current-value"].textContent = describeError(error);
       showError(error);
     } finally {
-      if (cellReads.isCurrent(token)) {
+      if (cellReads.isCurrent(token) && isCurrentTarget(target)) {
         editing.cellReadPending = false;
         updateCellEditorControls();
       }
@@ -351,6 +382,10 @@ export function createEditingController({
     if (!canEditWorkbook()) {
       return;
     }
+    const target = currentTarget();
+    const dialogGeneration = cellDialogGeneration;
+    const isCurrent = () =>
+      isCurrentTarget(target) && dialogGeneration === cellDialogGeneration;
     try {
       const coordinate = parseCellReference(elements["cell-reference"].value);
       if (!sameCellTarget(editing.cellReadTarget, cellTarget(coordinate))) {
@@ -371,28 +406,37 @@ export function createEditingController({
       updateCellEditorControls();
       elements["cell-current-value"].textContent =
         `Applying ${coordinate.normalized}`;
-      if (await commitCellEdit(cellTarget(coordinate), value))
+      if ((await commitCellEdit(cellTarget(coordinate), value)) && isCurrent())
         closeCellEditor();
     } catch (error) {
-      elements["cell-current-value"].textContent = describeError(error);
-      showError(error);
+      if (isCurrent()) {
+        elements["cell-current-value"].textContent = describeError(error);
+        showError(error);
+      }
     } finally {
-      editing.cellEditPending = false;
-      updateCellEditorControls();
-      updateCellKindUi();
+      if (isCurrent()) {
+        editing.cellEditPending = false;
+        updateCellEditorControls();
+        updateCellKindUi();
+      }
     }
   }
 
   async function openPropertiesEditor() {
-    if (state.busy || mutationPending) return;
+    if (state.busy || hasPendingMutation()) return;
+    const target = currentTarget();
     if (beforeCommand && !(await beforeCommand())) return;
-    if (!canEditWorkbook()) {
+    if (!isCurrentTarget(target) || !canEditWorkbook()) {
       return;
     }
+    if (elements["properties-dialog"].open) return;
     const properties = state.workbook.properties;
     for (const [property, elementId] of propertyFields()) {
       elements[elementId].value = properties[property] ?? "";
     }
+    propertiesDialogGeneration++;
+    propertiesBaseline = snapshot(propertyFields().map(([, id]) => id));
+    setFormPending(elements["properties-form"], false);
     if (!elements["properties-dialog"].open) {
       elements["properties-dialog"].showModal();
     }
@@ -400,6 +444,9 @@ export function createEditingController({
   }
 
   function closePropertiesEditor() {
+    propertiesDialogGeneration++;
+    propertiesBaseline = null;
+    setFormPending(elements["properties-form"], false);
     if (elements["properties-dialog"].open) {
       elements["properties-dialog"].close();
     }
@@ -411,7 +458,8 @@ export function createEditingController({
       return;
     }
     const target = currentTarget();
-    mutationPending = true;
+    const dialogGeneration = propertiesDialogGeneration;
+    mutationPending = target;
     try {
       setFormPending(elements["properties-form"], true);
       setBusy(true, "Updating document properties");
@@ -431,8 +479,10 @@ export function createEditingController({
     } catch (error) {
       if (isCurrentTarget(target)) showError(error);
     } finally {
-      mutationPending = false;
-      setFormPending(elements["properties-form"], false);
+      if (mutationPending === target) mutationPending = null;
+      if (dialogGeneration === propertiesDialogGeneration) {
+        setFormPending(elements["properties-form"], false);
+      }
       if (isCurrentTarget(target)) {
         setBusy(false);
       }
@@ -440,12 +490,13 @@ export function createEditingController({
   }
 
   async function applyHistoryEdit(direction) {
-    if (state.busy || mutationPending) return;
+    if (state.busy || hasPendingMutation() || rejectUnappliedDrafts()) return;
+    const target = currentTarget();
     if (beforeCommand && !(await beforeCommand())) return;
-    if (!canEditWorkbook()) {
+    if (!isCurrentTarget(target) || !canEditWorkbook()) {
       return;
     }
-    const target = currentTarget();
+    mutationPending = target;
     try {
       setBusy(true, direction === "undo" ? "Undoing edit" : "Redoing edit");
       const result =
@@ -460,9 +511,11 @@ export function createEditingController({
       );
     } catch (error) {
       if (isCurrentTarget(target)) {
-        setBusy(false);
         showError(error);
       }
+    } finally {
+      if (mutationPending === target) mutationPending = null;
+      if (isCurrentTarget(target)) setBusy(false);
     }
   }
 
@@ -585,7 +638,47 @@ export function createEditingController({
 
   /** Commit a captured cell target through the same retained-package/render path as the dialog. */
   async function commitCellEdit(target, value) {
-    if (!canEditWorkbook() || mutationPending) {
+    return commitMutation(
+      target,
+      (operation) => {
+        const setCell =
+          typeof operation.client.setCellAndRecalculate === "function"
+            ? operation.client.setCellAndRecalculate
+            : operation.client.setCell;
+        return setCell.call(
+          operation.client,
+          operation.documentId,
+          operation.sheetIndex,
+          target.row,
+          target.col,
+          value,
+        );
+      },
+      () => `${cellReference(target.row, target.col)} updated`,
+    );
+  }
+
+  /** Apply a bounded rectangular paste as one worker mutation and one undo entry. */
+  async function commitRangeEdit(target, values) {
+    if (typeof target?.client?.setRangeAndRecalculate !== "function") {
+      throw new Error("This rendering runtime does not support range editing.");
+    }
+    return commitMutation(
+      target,
+      (operation) =>
+        operation.client.setRangeAndRecalculate(
+          operation.documentId,
+          operation.sheetIndex,
+          target.row,
+          target.col,
+          values,
+        ),
+      "Pasted cells updated",
+    );
+  }
+
+  async function commitMutation(target, apply, message) {
+    if (!canEditWorkbook() || hasPendingMutation()) {
       throw new Error(
         "Cell editing is unavailable while the workbook is read-only or busy.",
       );
@@ -607,30 +700,23 @@ export function createEditingController({
         "The cell reference is outside the XLSX worksheet grid.",
       );
     }
-    mutationPending = true;
+    const operation = currentTarget();
+    mutationPending = operation;
     setBusy(true, "Applying cell edit");
     try {
-      const setCell =
-        typeof target.client.setCellAndRecalculate === "function"
-          ? target.client.setCellAndRecalculate
-          : target.client.setCell;
-      const result = await setCell.call(
-        target.client,
-        target.documentId,
-        target.sheetIndex,
-        target.row,
-        target.col,
-        value,
-      );
-      if (!isCurrentTarget(target)) return false;
+      const result = await apply(operation);
+      if (!isCurrentTarget(operation)) return false;
       return await applyMutationResult(
         result,
-        `${cellReference(target.row, target.col)} updated`,
-        target,
+        typeof message === "function" ? message() : message,
+        operation,
       );
+    } catch (error) {
+      if (!isCurrentTarget(operation)) return false;
+      throw error;
     } finally {
-      mutationPending = false;
-      if (isCurrentTarget(target)) setBusy(false);
+      if (mutationPending === operation) mutationPending = null;
+      if (isCurrentTarget(operation)) setBusy(false);
     }
   }
 
@@ -639,7 +725,9 @@ export function createEditingController({
       target &&
         target.client === state.client &&
         target.documentId === state.documentId &&
-        target.sheetIndex === state.sheetIndex,
+        target.sheetIndex === state.sheetIndex &&
+        (target.openGeneration === undefined ||
+          target.openGeneration === (state.openGeneration ?? 0)),
     );
   }
 
@@ -648,6 +736,7 @@ export function createEditingController({
       client: state.client,
       documentId: state.documentId,
       sheetIndex: state.sheetIndex,
+      openGeneration: state.openGeneration ?? 0,
     };
   }
 
@@ -660,36 +749,45 @@ export function createEditingController({
   }
 
   async function saveWorkbookCopy() {
-    if (state.busy || mutationPending) return;
+    if (state.busy || hasPendingMutation() || rejectUnappliedDrafts()) return;
+    const target = currentTarget();
     if (beforeCommand && !(await beforeCommand())) return;
-    if (!canEditWorkbook()) {
+    if (
+      !isCurrentTarget(target) ||
+      !canEditWorkbook() ||
+      rejectUnappliedDrafts()
+    ) {
       return;
     }
+    const fileName = state.file.name;
     try {
       setBusy(true, "Preparing preserved workbook");
-      const saved = await state.client.saveDocument(state.documentId);
-      const extension = extensionOf(state.file.name);
+      const saved = await target.client.saveDocument(target.documentId);
+      if (!isCurrentTarget(target)) return;
+      const extension = extensionOf(fileName);
       const mimeType =
         extension === "xlsm"
           ? "application/vnd.ms-excel.sheet.macroEnabled.12"
           : "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
       download(
         new Blob([saved.bytes], { type: mimeType }),
-        savedWorkbookName(state.file.name),
+        savedWorkbookName(fileName),
       );
       elements["status-message"].textContent = "Preserved workbook downloaded";
     } catch (error) {
-      showError(error);
+      if (isCurrentTarget(target)) showError(error);
     } finally {
-      setBusy(false);
-      elements["export-menu"].removeAttribute("open");
+      if (isCurrentTarget(target)) {
+        setBusy(false);
+        elements["export-menu"].removeAttribute("open");
+      }
     }
   }
 
   function canEditWorkbook() {
     return Boolean(
       !readOnly &&
-        !mutationPending &&
+        !hasPendingMutation() &&
         state.client &&
         state.workbook &&
         !state.busy &&
@@ -698,13 +796,73 @@ export function createEditingController({
   }
 
   function confirmDiscardChanges() {
+    const draft = hasDraftChanges();
     return (
-      !state.editState?.dirty || confirm("Discard unsaved workbook edits?")
+      !(state.editState?.dirty || draft) ||
+      confirm(
+        draft
+          ? "Discard unsaved workbook edits and unapplied dialog changes?"
+          : "Discard unsaved workbook edits?",
+      )
     );
   }
 
+  function hasPendingMutation() {
+    return Boolean(mutationPending && isCurrentTarget(mutationPending));
+  }
+
+  function cellFields() {
+    return [
+      "cell-reference",
+      "cell-kind",
+      "cell-value",
+      "cell-formula",
+      "cell-cached-kind",
+      "cell-cached-value",
+    ];
+  }
+
+  function snapshot(fields) {
+    return {
+      target: currentTarget(),
+      values: Object.fromEntries(fields.map((id) => [id, elements[id].value])),
+    };
+  }
+
+  function changedSnapshot(baseline, fields) {
+    return Boolean(
+      baseline &&
+        isCurrentTarget(baseline.target) &&
+        fields.some((id) => baseline.values[id] !== elements[id].value),
+    );
+  }
+
+  function hasDraftChanges() {
+    return Boolean(
+      (elements["cell-dialog"].open &&
+        changedSnapshot(cellBaseline, cellFields())) ||
+        (elements["properties-dialog"].open &&
+          changedSnapshot(
+            propertiesBaseline,
+            propertyFields().map(([, id]) => id),
+          )),
+    );
+  }
+
+  function rejectUnappliedDrafts() {
+    if (!hasDraftChanges()) return false;
+    showError(
+      new Error(
+        "Apply or Cancel the unapplied dialog changes before continuing.",
+      ),
+    );
+    return true;
+  }
+
   function setFormPending(form, pending) {
-    for (const button of form.querySelectorAll("button")) {
+    for (const button of form.querySelectorAll(
+      "button, input, textarea, select",
+    )) {
       button.disabled = pending;
     }
   }

--- a/viewer/src/grid-editor.js
+++ b/viewer/src/grid-editor.js
@@ -128,6 +128,7 @@ export function createGridEditor({
   const input = elements["grid-input"];
   const status = elements["grid-status"];
   let cells = [];
+  const cellIndices = new Map();
   let svg = null;
   let context = null;
   let selected = null;
@@ -177,6 +178,8 @@ export function createGridEditor({
     commit,
     select,
     beginEdit,
+    getPasteTarget,
+    applyRange,
   };
 
   function snapshot() {
@@ -248,6 +251,9 @@ export function createGridEditor({
         return false;
       }
       cells = nextCells;
+      cellIndices.clear();
+      for (let index = 0; index < cells.length; index++)
+        cellIndices.set(cells[index].key, index);
       context = nextContext;
       svg = nextSvg;
       if (layer.parentElement !== surface) surface.append(layer);
@@ -256,7 +262,7 @@ export function createGridEditor({
         loaded = null;
         request += 1;
       }
-      selected = cells.find((cell) => cell.key === selected?.key) ?? null;
+      selected = cells[cellIndices.get(selected?.key)] ?? null;
       if (committing || draft) {
         update();
         reposition();
@@ -284,6 +290,7 @@ export function createGridEditor({
     readPromise = null;
     svg = null;
     cells = [];
+    cellIndices.clear();
     if (!preserveSelection) selected = null;
     layer.hidden = true;
     outline.hidden = true;
@@ -355,7 +362,8 @@ export function createGridEditor({
 
   async function select(row, col, { focus = true } = {}) {
     if (!available()) return false;
-    const next = cells.find((cell) => cell.row === row && cell.col === col);
+    if (!Number.isInteger(row) || !Number.isInteger(col)) return false;
+    const next = cells[cellIndices.get(`${row}:${col}`)];
     if (!next) return false;
     if (selected?.key === next.key) {
       if (focus) {
@@ -391,6 +399,7 @@ export function createGridEditor({
       row: selected.row,
       col: selected.col,
       key: selected.key,
+      openGeneration: state.openGeneration,
     };
     const promise = (async () => {
       try {
@@ -403,6 +412,7 @@ export function createGridEditor({
         if (
           token !== request ||
           !sameContext(target) ||
+          target.openGeneration !== state.openGeneration ||
           target.key !== selected?.key
         )
           return null;
@@ -423,7 +433,11 @@ export function createGridEditor({
         );
         return loaded;
       } catch (error) {
-        if (token === request && sameContext(target)) {
+        if (
+          token === request &&
+          sameContext(target) &&
+          target.openGeneration === state.openGeneration
+        ) {
           announce(describeError(error));
           showError(error);
         }
@@ -477,9 +491,15 @@ export function createGridEditor({
     startDraft(replacement);
     if (!draft) return false;
     const current = draft;
+    const generation = state.openGeneration;
     input.focus({ preventScroll: true });
     if (!current.original) await (readPromise ?? readSelected());
-    if (draft !== current || !sameContext(current.target)) return false;
+    if (
+      draft !== current ||
+      !sameContext(current.target) ||
+      generation !== state.openGeneration
+    )
+      return false;
     if (!current.original) {
       announce(
         "The cell could not be read. Your draft is retained; retry or press Escape.",
@@ -503,6 +523,63 @@ export function createGridEditor({
     return true;
   }
 
+  function getPasteTarget() {
+    if (!available() || !selected || composing) return null;
+    return {
+      ...snapshot(),
+      row: selected.row,
+      col: selected.col,
+      key: selected.key,
+      openGeneration: state.openGeneration,
+    };
+  }
+
+  async function applyRange(target, values) {
+    const isCurrent = () =>
+      sameContext(target) &&
+      target.openGeneration === state.openGeneration &&
+      selected?.key === target.key;
+    if (!available() || composing || !isCurrent()) return false;
+    try {
+      committing = true;
+      update();
+      const applied = await editing.commitRangeEdit(target, values);
+      if (
+        !applied ||
+        !sameContext(target) ||
+        target.openGeneration !== state.openGeneration
+      )
+        return false;
+      draft = null;
+      input.value = "";
+      loaded = null;
+      notifyDraft();
+      announce("Pasted range updated. Undo restores the entire range.");
+      return true;
+    } catch (error) {
+      if (
+        sameContext(target) &&
+        target.openGeneration === state.openGeneration
+      ) {
+        announce(
+          `${describeError(error)} The range was not applied; your draft is retained.`,
+        );
+        showError(error);
+      }
+      return false;
+    } finally {
+      committing = false;
+      update();
+      if (
+        !draft &&
+        available() &&
+        sameContext(target) &&
+        target.openGeneration === state.openGeneration
+      )
+        void readSelected();
+    }
+  }
+
   async function commit() {
     if (committing || composing) return false;
     if (!draft) return true;
@@ -513,11 +590,13 @@ export function createGridEditor({
       return false;
     }
     const current = draft;
+    const generation = state.openGeneration;
     if (!current.original) {
       await readSelected();
       if (
         draft !== current ||
         !current.original ||
+        generation !== state.openGeneration ||
         !sameContext(current.target)
       )
         return false;
@@ -533,7 +612,12 @@ export function createGridEditor({
       committing = true;
       update();
       const applied = await editing.commitCellEdit(current.target, value);
-      if (!applied || !sameContext(current.target)) {
+      if (
+        !applied ||
+        !sameContext(current.target) ||
+        generation !== state.openGeneration
+      ) {
+        if (generation !== state.openGeneration) return false;
         announce(
           "The workbook changed before the edit completed. The draft was retained.",
         );
@@ -546,8 +630,10 @@ export function createGridEditor({
       announce(`${selected?.reference ?? "Cell"} updated.`);
       return true;
     } catch (error) {
-      announce(`${describeError(error)} Your draft is retained.`);
-      showError(error);
+      if (sameContext(current.target) && generation === state.openGeneration) {
+        announce(`${describeError(error)} Your draft is retained.`);
+        showError(error);
+      }
       return false;
     } finally {
       committing = false;
@@ -557,6 +643,7 @@ export function createGridEditor({
       if (
         draft === current &&
         sameContext(current.target) &&
+        generation === state.openGeneration &&
         hadInputFocus &&
         available() &&
         !input.disabled &&
@@ -565,7 +652,8 @@ export function createGridEditor({
           ownerDocument.activeElement === input)
       )
         input.focus({ preventScroll: true });
-      if (!draft && available()) void readSelected();
+      if (!draft && available() && generation === state.openGeneration)
+        void readSelected();
     }
   }
 
@@ -601,12 +689,12 @@ export function createGridEditor({
   function adjacent(direction) {
     if (!selected) return null;
     if (direction === "next" || direction === "previous") {
-      const index = cells.findIndex((cell) => cell.key === selected.key);
+      const index = cellIndices.get(selected.key);
       return cells[index + (direction === "next" ? 1 : -1)] ?? null;
     }
     const x = selected.x + Math.min(1, selected.width / 2);
     const y = selected.y + Math.min(1, selected.height / 2);
-    const eligible = cells.filter((cell) => {
+    const eligible = (cell) => {
       if (direction === "right")
         return (
           cell.x >= selected.x + selected.width - 0.001 &&
@@ -630,7 +718,7 @@ export function createGridEditor({
         x >= cell.x &&
         x < cell.x + cell.width
       );
-    });
+    };
     const distance = (cell) =>
       direction === "right"
         ? cell.x - selected.x
@@ -639,7 +727,17 @@ export function createGridEditor({
           : direction === "down"
             ? cell.y - selected.y
             : selected.y - cell.y - cell.height;
-    return eligible.sort((a, b) => distance(a) - distance(b))[0] ?? selected;
+    let nearest = selected;
+    let nearestDistance = Infinity;
+    for (const cell of cells) {
+      if (!eligible(cell)) continue;
+      const nextDistance = distance(cell);
+      if (nextDistance < nearestDistance) {
+        nearest = cell;
+        nearestDistance = nextDistance;
+      }
+    }
+    return nearest;
   }
 
   async function keydown(event) {

--- a/viewer/src/main.js
+++ b/viewer/src/main.js
@@ -42,6 +42,7 @@ import { createEditingController } from "./editing.js";
 import { createExportController } from "./exports.js";
 import { createWorkbench } from "./workbench.js";
 import { createGridEditor } from "./grid-editor.js";
+import { createRangePasteController } from "./range-paste.js";
 
 const MAX_INPUT_BYTES = 32 * 1024 * 1024;
 const ZOOM_STEP = 0.15;
@@ -169,6 +170,13 @@ const elements = Object.fromEntries(
     "property-last-modified-by",
     "property-company",
     "property-created",
+    "paste-dialog",
+    "paste-status",
+    "paste-summary",
+    "paste-preview",
+    "apply-range-paste",
+    "paste-as-text",
+    "cancel-range-paste",
   ].map((id) => [id, document.getElementById(id)]),
 );
 
@@ -191,6 +199,7 @@ const state = {
   busy: false,
   renderEpoch: 0,
   openRequest: null,
+  openGeneration: 0,
   dragDepth: 0,
   hostGeneration: 0,
   hostWorker: null,
@@ -202,6 +211,7 @@ const baseUrl = hostResourceBase
 const openRequests = createLatestRequestGate();
 let samples = [];
 let grid = null;
+let rangePaste = null;
 
 const editing = createEditingController({
   state,
@@ -211,7 +221,7 @@ const editing = createEditingController({
   showError,
   updateWorkbookUi,
   renderCurrent,
-  beforeCommand: () => (grid ? grid.commit() : Promise.resolve(true)),
+  beforeCommand: commitGridDraft,
 });
 const {
   updateEditUi,
@@ -260,6 +270,13 @@ grid = createGridEditor({
   focusOutsideGrid,
   showError,
 });
+
+rangePaste = createRangePasteController({ grid, elements, showError });
+
+async function commitGridDraft() {
+  if (rangePaste && !rangePaste.ready()) return false;
+  return grid ? grid.commit() : true;
+}
 
 function focusOutsideGrid(direction) {
   const surface = elements["document-surface"];
@@ -383,7 +400,12 @@ function bindEvents() {
   }
   window.addEventListener("keydown", onKeyDown);
   window.addEventListener("beforeunload", (event) => {
-    if (state.editState?.dirty || grid.hasChanges()) {
+    if (
+      state.editState?.dirty ||
+      grid.hasChanges() ||
+      editing.hasDraftChanges() ||
+      rangePaste.hasPending()
+    ) {
       event.preventDefault();
       event.returnValue = "";
     }
@@ -400,7 +422,8 @@ function chooseFile() {
 }
 
 async function loadLocalFile(file) {
-  if (!(await grid.commit())) return;
+  if (!canReplaceWorkbook()) return;
+  if (!(await commitGridDraft())) return;
   if (!confirmDiscardChanges()) {
     return;
   }
@@ -438,7 +461,11 @@ async function loadLocalFile(file) {
 }
 
 async function loadSample(sample) {
-  if (!(await grid.commit())) {
+  if (!canReplaceWorkbook()) {
+    elements["sample-select"].value = state.file?.sampleId ?? "";
+    return;
+  }
+  if (!(await commitGridDraft())) {
     elements["sample-select"].value = state.file?.sampleId ?? "";
     return;
   }
@@ -473,7 +500,19 @@ async function loadSample(sample) {
   }
 }
 
+function canReplaceWorkbook() {
+  if (!editing.hasPendingMutation()) return true;
+  showError(
+    new Error(
+      "Wait for the current edit to finish before opening another workbook.",
+    ),
+  );
+  return false;
+}
+
 function beginOpenRequest(label) {
+  rangePaste.cancel();
+  state.openGeneration += 1;
   state.openRequest?.abortController.abort();
   state.openRequest?.client?.terminate();
   const request = {
@@ -736,7 +775,7 @@ async function selectSheet(index) {
   if (state.busy || index === state.sheetIndex || !state.workbook) {
     return;
   }
-  if (!(await grid.commit())) return;
+  if (!(await commitGridDraft())) return;
   if (state.busy || !state.workbook || index === state.sheetIndex) return;
   grid.invalidate();
   state.sheetIndex = index;
@@ -750,7 +789,7 @@ async function setMode(mode) {
   if (!state.workbook || state.busy || state.mode === mode) {
     return;
   }
-  if (!(await grid.commit())) return;
+  if (!(await commitGridDraft())) return;
   if (state.busy || !state.workbook || mode === state.mode) return;
   grid.invalidate();
   state.mode = mode;
@@ -932,7 +971,7 @@ function applyZoom() {
 }
 
 async function exportWithDraft(kind) {
-  if (!(await grid.commit())) return;
+  if (!(await commitGridDraft())) return;
   if (kind === "svg") exportSvg();
   else await exportPng();
 }
@@ -1112,11 +1151,7 @@ function onKeyDown(event) {
     chooseFile();
     return;
   }
-  if (
-    (!editingText || event.target === elements["grid-input"]) &&
-    key === "s" &&
-    state.editState?.capability === "read-write"
-  ) {
+  if (key === "s" && state.editState?.capability === "read-write") {
     event.preventDefault();
     void saveWorkbookCopy();
     return;

--- a/viewer/src/range-paste.js
+++ b/viewer/src/range-paste.js
@@ -1,0 +1,149 @@
+import { MAX_PASTE_BYTES, rangePasteRequest } from "./clipboard.js";
+import { describeError } from "./core.js";
+
+/** Preview native clipboard events before submitting one atomic worker transaction. */
+export function createRangePasteController({ grid, elements, showError }) {
+  const dialog = elements["paste-dialog"];
+  const status = elements["paste-status"];
+  const summary = elements["paste-summary"];
+  const preview = elements["paste-preview"];
+  const applyButton = elements["apply-range-paste"];
+  const textButton = elements["paste-as-text"];
+  const cancelButton = elements["cancel-range-paste"];
+  let pending = null;
+  let applying = false;
+
+  elements["document-surface"].addEventListener("paste", onPaste);
+  applyButton.addEventListener("click", () => void apply(false));
+  textButton.addEventListener("click", () => void apply(true));
+  cancelButton.addEventListener("click", () => cancel());
+  dialog.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    if (!applying) cancel();
+  });
+  dialog.addEventListener("keydown", (event) => {
+    // Keep Escape owned by this modal; the window shortcut cancels cell drafts.
+    if (event.key === "Escape") event.stopPropagation();
+    if (
+      (event.ctrlKey || event.metaKey) &&
+      ["o", "s", "z", "y"].includes(event.key.toLowerCase())
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      ready();
+    }
+  });
+  return { hasPending: () => Boolean(pending), ready, cancel };
+
+  function ready() {
+    if (!pending) return true;
+    status.textContent = applying
+      ? "Applying the range…"
+      : "Apply or cancel the paste before using another command.";
+    return false;
+  }
+
+  function close() {
+    pending = null;
+    preview.replaceChildren();
+    if (dialog.open) dialog.close();
+  }
+
+  function cancel() {
+    if (applying) return false;
+    close();
+    return true;
+  }
+
+  function onPaste(event) {
+    if (pending || applying || event.defaultPrevented) return;
+    const target = grid.getPasteTarget();
+    if (!target || event.isComposing) return;
+    const text = event.clipboardData?.getData("text/plain");
+    if (typeof text !== "string" || !/[\t\r\n]/.test(text)) return;
+    event.preventDefault();
+    if (
+      text.length > MAX_PASTE_BYTES ||
+      new TextEncoder().encode(text).length > MAX_PASTE_BYTES
+    ) {
+      showError(
+        new RangeError("Clipboard size exceeds the 1 MiB paste limit."),
+      );
+      return;
+    }
+    let request = null;
+    let parseError = null;
+    try {
+      request = rangePasteRequest(text, target.row, target.col, target);
+    } catch (error) {
+      parseError = error;
+    }
+    pending = { target, text, request };
+    applying = false;
+    applyButton.disabled = !request;
+    textButton.disabled = false;
+    cancelButton.disabled = false;
+    preview.replaceChildren();
+    summary.textContent = request
+      ? `${request.reference} · ${request.rows.length} rows × ${request.rows[0].length} columns · ${request.cellCount.toLocaleString("en-US")} cells`
+      : "This clipboard cannot be pasted as a range.";
+    status.textContent = parseError
+      ? describeError(parseError)
+      : "Applying replaces these cells and any current in-cell draft. Undo restores the whole range. Formulas use the pasted references as written.";
+    if (request) {
+      const document = preview.ownerDocument;
+      for (const row of request.rows.slice(0, 5)) {
+        const tr = document.createElement("tr");
+        for (const value of row.slice(0, 5)) {
+          const td = document.createElement("td");
+          td.textContent =
+            value.length > 80 ? `${value.slice(0, 80)}…` : value || "(blank)";
+          tr.append(td);
+        }
+        preview.append(tr);
+      }
+    }
+    dialog.showModal();
+    // Enter must not apply an unreviewed overwrite immediately after paste.
+    cancelButton.focus();
+  }
+
+  async function apply(asText) {
+    if (!pending || applying) return;
+    const current = pending;
+    let request;
+    try {
+      request = asText
+        ? rangePasteRequest(
+            current.text,
+            current.target.row,
+            current.target.col,
+            { ...current.target, asText: true },
+          )
+        : current.request;
+      if (!request) return;
+    } catch (error) {
+      status.textContent = describeError(error);
+      return;
+    }
+    applying = true;
+    applyButton.disabled = textButton.disabled = cancelButton.disabled = true;
+    status.textContent = "Applying the range…";
+    try {
+      if (await grid.applyRange(current.target, request.values)) close();
+      else
+        status.textContent =
+          "The paste was not applied. Your draft is retained. Check the error or cancel and select the destination again.";
+    } catch (error) {
+      status.textContent = describeError(error);
+      showError(error);
+    } finally {
+      applying = false;
+      if (pending === current) {
+        applyButton.disabled = !current.request;
+        textButton.disabled = cancelButton.disabled = false;
+        cancelButton.focus();
+      }
+    }
+  }
+}

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -420,7 +420,8 @@ button:disabled {
   background: var(--surface);
   border-bottom: 1px solid var(--border);
 }
-.formula-bar input {
+.formula-bar input,
+.formula-bar textarea {
   min-width: 0;
   height: 29px;
   border: 1px solid transparent;
@@ -434,6 +435,7 @@ button:disabled {
   text-align: center;
 }
 #inspector-value {
+  resize: none;
   flex: 1;
   font-family: "Segoe UI", sans-serif;
   text-overflow: ellipsis;
@@ -882,6 +884,36 @@ button:disabled {
 
 .edit-dialog::backdrop {
   background: rgb(20 25 22 / 48%);
+}
+
+.paste-preview-container {
+  overflow: auto;
+  min-height: 0;
+  padding: 16px;
+}
+
+.paste-preview {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.paste-preview td {
+  min-width: 70px;
+  max-width: 220px;
+  padding: 7px;
+  border: 1px solid var(--border);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.paste-form .dialog-actions {
+  flex-wrap: wrap;
+}
+
+.paste-form .dialog-status {
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .edit-form {

--- a/viewer/tests/browser.mjs
+++ b/viewer/tests/browser.mjs
@@ -10,6 +10,8 @@ import {
   PRESERVED_PARTS,
 } from "../scripts/preservation-fixture.mjs";
 import { createStoredZip, readZipEntries } from "../scripts/zip.mjs";
+import { exerciseRangePaste, exerciseLargeRangePaste } from "./range-paste.mjs";
+import { exerciseEditingGuards } from "./editing-guards.mjs";
 
 const execFileAsync = promisify(execFile);
 const port = Number(process.env.RXLS_VIEWER_PORT || 4173);
@@ -172,6 +174,19 @@ try {
   );
 
   await exerciseInlineEditing(page);
+  await exerciseEditingGuards(page, { waitForCondition, waitForViewerState });
+  await exerciseRangePaste(page, {
+    waitForCondition,
+    waitForViewerState,
+    downloadWorkbook,
+    assertOpenpyxlReopens,
+  });
+  await exerciseLargeRangePaste(page, {
+    waitForCondition,
+    waitForViewerState,
+    downloadWorkbook,
+    assertOpenpyxlReopens,
+  });
   await exerciseMutationContinuity(page);
 
   const state = await page.evaluate(() => globalThis.__rxlsViewerState());

--- a/viewer/tests/clipboard.test.mjs
+++ b/viewer/tests/clipboard.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseClipboardRange,
+  rangePasteRequest,
+  MAX_PASTE_BYTES,
+} from "../src/clipboard.js";
+
+test("clipboard TSV keeps quoted separators, blank cells and CRLF rows", () => {
+  assert.deepEqual(
+    parseClipboardRange('1\t"two\tparts"\t\r\n3\t"two\r\nlines"\t"a""b"\r\n'),
+    [
+      ["1", "two\tparts", ""],
+      ["3", "two\nlines", 'a"b'],
+    ],
+  );
+  assert.deepEqual(parseClipboardRange("a\n\n"), [["a"], [""]]);
+  assert.deepEqual(parseClipboardRange("\t\n"), [["", ""]]);
+  assert.deepEqual(parseClipboardRange('"line one\nline two"'), [
+    ["line one\nline two"],
+  ]);
+  assert.deepEqual(parseClipboardRange('ordinary "quote"'), [
+    ['ordinary "quote"'],
+  ]);
+});
+
+test("clipboard rejects malformed, ragged and oversized rectangles before application", () => {
+  for (const text of [
+    "",
+    '"unfinished',
+    '"closed"suffix',
+    "a\tb\nc",
+    "a\nb\tc",
+  ])
+    assert.throws(
+      () => parseClipboardRange(text),
+      /clipboard|rectang|quot|empty/i,
+    );
+  assert.throws(
+    () => parseClipboardRange("x".repeat(MAX_PASTE_BYTES + 1)),
+    /size/i,
+  );
+  assert.throws(
+    () => parseClipboardRange("한".repeat(Math.floor(MAX_PASTE_BYTES / 3) + 1)),
+    /size/i,
+  );
+  assert.throws(
+    () => parseClipboardRange(Array(10_001).fill("1").join("\t")),
+    /10,000/,
+  );
+});
+
+test("range paste uses existing scalar rules and bounded worksheet coordinates", () => {
+  const request = rangePasteRequest("001\tTRUE\t\n=1+2\t'004\t-2.5\n", 3, 1);
+  assert.equal(request.reference, "B4:D5");
+  assert.equal(request.cellCount, 6);
+  assert.deepEqual(request.values, [
+    [
+      { kind: "text", value: "001" },
+      { kind: "boolean", value: true },
+      { kind: "blank" },
+    ],
+    [
+      { kind: "formula-auto", formula: "1+2" },
+      { kind: "text", value: "004" },
+      { kind: "number", value: -2.5 },
+    ],
+  ]);
+  assert.throws(() => rangePasteRequest("1\t2", 0, 16_383), /worksheet/i);
+  assert.throws(() => rangePasteRequest("1\n2", 1_048_575, 0), /worksheet/i);
+  for (const coordinate of [-1, 0.5, NaN, Infinity])
+    assert.throws(() => rangePasteRequest("1", coordinate, 0), /worksheet/i);
+  assert.throws(() => rangePasteRequest("1e999\t2", 0, 0), /finite/i);
+  assert.throws(() => rangePasteRequest("=\t2", 0, 0), /formula/i);
+});
+
+test("serialized range budget includes escaping and typed-cell overhead", () => {
+  assert.throws(
+    () => rangePasteRequest("\\".repeat(MAX_PASTE_BYTES / 2 + 1), 0, 0),
+    /size/i,
+  );
+  assert.equal(
+    rangePasteRequest("a\nb", 0, 0, { asText: true }).values[0][0].value,
+    "a\nb",
+  );
+  assert.equal(
+    rangePasteRequest("=1+2\t3", 0, 0, { asText: true }).values[0][0].kind,
+    "text",
+  );
+});

--- a/viewer/tests/editing-guards.mjs
+++ b/viewer/tests/editing-guards.mjs
@@ -1,0 +1,310 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const samplePath = fileURLToPath(
+  new URL("../samples/operations-report.xlsx", import.meta.url),
+);
+
+/** Run on a clean, editable operations-report sample, and leave a fresh local copy. */
+export async function exerciseEditingGuards(
+  page,
+  { waitForCondition, waitForViewerState },
+) {
+  const idle = (label) =>
+    waitForViewerState(
+      page,
+      (state) =>
+        state.fileName === "operations-report.xlsx" &&
+        state.rendered &&
+        !state.busy &&
+        !state.dirty,
+      label,
+    );
+  const downloads = [];
+  const onDownload = (download) => downloads.push(download.suggestedFilename());
+  page.on("download", onDownload);
+  try {
+    await page.getByRole("tab", { name: "Home", exact: true }).click();
+    for (const kind of ["cell", "properties"]) {
+      await page
+        .locator(kind === "cell" ? "#edit-cell" : "#document-properties")
+        .click();
+      await page.locator(`#${kind}-dialog`).waitFor({ state: "visible" });
+      if (kind === "cell") {
+        await waitForCondition(
+          async () => !(await page.locator("#apply-cell-edit").isDisabled()),
+          "dialog cell read",
+        );
+        await page.locator("#cell-kind").selectOption("number");
+        await page.locator("#cell-value").fill("invalid number draft");
+      } else {
+        await page.locator("#property-title").fill("Unapplied metadata draft");
+        await page.locator("#property-created").fill("2026-09-08T15:30");
+      }
+      assert.equal(
+        await page.evaluate(() => {
+          const event = new Event("beforeunload", { cancelable: true });
+          window.dispatchEvent(event);
+          return event.defaultPrevented;
+        }),
+        true,
+        `${kind} draft must guard reload/unload`,
+      );
+      await page.keyboard.press("ControlOrMeta+s");
+      await waitForCondition(
+        async () =>
+          /Apply or Cancel/.test(
+            await page.locator("#error-message").textContent(),
+          ),
+        "unapplied save warning",
+      );
+      assert.equal(
+        downloads.length,
+        0,
+        "save must not omit unapplied dialog fields",
+      );
+      const draftField = kind === "cell" ? "#cell-value" : "#property-title";
+      const draftValue = await page.locator(draftField).inputValue();
+      await Promise.all([
+        page.waitForEvent("dialog").then(async (dialog) => {
+          assert.equal(dialog.type(), "confirm");
+          assert.match(dialog.message(), /unapplied dialog changes/);
+          await dialog.dismiss();
+        }),
+        page.locator("#file-input").setInputFiles(samplePath),
+      ]);
+      assert.equal(await page.locator(draftField).inputValue(), draftValue);
+      assert.equal(await page.locator(`#${kind}-dialog`).isVisible(), true);
+      await page.locator(`#cancel-${kind}-edit`).click();
+      assert.equal(
+        await page.evaluate(() => {
+          const event = new Event("beforeunload", { cancelable: true });
+          window.dispatchEvent(event);
+          return event.defaultPrevented;
+        }),
+        false,
+        "explicit Cancel clears only the unapplied draft",
+      );
+      if (await page.locator("#error-banner").isVisible())
+        await page.locator("#dismiss-error").click();
+    }
+
+    // Accepted discard goes through the same real file-open event as a picker selection.
+    await page.locator("#document-properties").click();
+    await page
+      .locator("#property-description")
+      .fill("Discard this unapplied draft");
+    await Promise.all([
+      page.waitForEvent("dialog").then((dialog) => dialog.accept()),
+      page.locator("#file-input").setInputFiles(samplePath),
+    ]);
+    await page.locator("#properties-dialog").waitFor({ state: "hidden" });
+    await idle("accepted unapplied-dialog discard");
+
+    for (const command of ["save"]) {
+      for (const outcome of ["resolve", "reject"]) {
+        for (const replacement of ["pending", "complete"]) {
+          await installDelays(page, command, outcome);
+          try {
+            await page.locator("#quick-save").click();
+            await waitForCondition(
+              () =>
+                page.evaluate(() => globalThis.__rxlsEditingGuards.captured),
+              "worker result captured before replacement",
+            );
+            await page.locator("#file-input").setInputFiles(samplePath);
+            await waitForCondition(
+              () =>
+                page.evaluate(() => globalThis.__rxlsEditingGuards.openStarted),
+              "new open began before document identity changes",
+            );
+            if (replacement === "complete") {
+              await page.evaluate(() =>
+                globalThis.__rxlsEditingGuards.releaseOpen(),
+              );
+              await idle("replacement completes before old command response");
+            }
+            const before = await page.evaluate(() => ({
+              state: globalThis.__rxlsViewerState(),
+              status: document.getElementById("status-message").textContent,
+            }));
+            await page.evaluate(() =>
+              globalThis.__rxlsEditingGuards.releaseOperation(),
+            );
+            await waitForCondition(
+              () =>
+                page.evaluate(() => globalThis.__rxlsEditingGuards.finished),
+              "old command settles",
+            );
+            await page.evaluate(
+              () =>
+                new Promise((resolve) =>
+                  requestAnimationFrame(() => requestAnimationFrame(resolve)),
+                ),
+            );
+            const after = await page.evaluate(() => ({
+              state: globalThis.__rxlsViewerState(),
+              status: document.getElementById("status-message").textContent,
+            }));
+            assert.equal(
+              after.state.busy,
+              before.state.busy,
+              `${command}/${outcome}/${replacement}: busy state`,
+            );
+            assert.equal(
+              after.status,
+              before.status,
+              `${command}/${outcome}/${replacement}: status`,
+            );
+            assert.equal(after.state.dirty, false);
+            assert.equal(await page.locator("#error-banner").isHidden(), true);
+            assert.equal(
+              downloads.length,
+              0,
+              "an obsolete save must never download",
+            );
+            if (replacement === "pending") {
+              assert.equal(
+                after.state.busy,
+                true,
+                "the held replacement open must remain busy",
+              );
+              await page.evaluate(() =>
+                globalThis.__rxlsEditingGuards.releaseOpen(),
+              );
+              await idle("replacement completes after ignored old response");
+            }
+          } finally {
+            await page.evaluate(() =>
+              globalThis.__rxlsEditingGuards?.restore(),
+            );
+          }
+        }
+      }
+    }
+    for (const outcome of ["resolve", "reject"]) {
+      await installDelays(page, "cell", outcome);
+      try {
+        await page.locator("#edit-cell").click();
+        await page.locator("#cell-reference").fill("C4");
+        await page.locator("#read-cell").click();
+        await waitForCondition(
+          async () =>
+            !(await page.locator("#apply-cell-edit").isDisabled()) &&
+            (
+              await page.locator("#cell-current-value").textContent()
+            ).startsWith("C4:"),
+          "pending-submit source loaded",
+        );
+        await page.locator("#cell-value").fill("7");
+        await page.locator("#apply-cell-edit").click();
+        await waitForCondition(
+          () => page.evaluate(() => globalThis.__rxlsEditingGuards.captured),
+          "authoritative cell response held",
+        );
+        await page.locator("#file-input").setInputFiles(samplePath);
+        await waitForCondition(
+          async () =>
+            /wait.*edit|edit.*finish/i.test(
+              await page.locator("#error-message").textContent(),
+            ),
+          "replacement blocked while edit pending",
+        );
+        assert.equal(
+          await page.evaluate(() => globalThis.__rxlsEditingGuards.openStarted),
+          false,
+        );
+        assert.equal(
+          (await page.evaluate(() => globalThis.__rxlsViewerState())).busy,
+          true,
+        );
+        assert.equal(await page.locator("#cell-dialog").isVisible(), true);
+        assert.equal(await page.locator("#cell-value").inputValue(), "7");
+        await page.evaluate(() =>
+          globalThis.__rxlsEditingGuards.releaseOperation(),
+        );
+        await waitForViewerState(
+          page,
+          (state) => !state.busy && state.dirty === (outcome === "resolve"),
+          "authoritative edit settles before replacement",
+        );
+        if (outcome === "reject") {
+          assert.equal(await page.locator("#cell-dialog").isVisible(), true);
+          assert.equal(await page.locator("#cell-value").inputValue(), "7");
+        }
+      } finally {
+        await page.evaluate(() => globalThis.__rxlsEditingGuards?.restore());
+      }
+      await Promise.all([
+        page.waitForEvent("dialog").then((dialog) => dialog.accept()),
+        page.locator("#file-input").setInputFiles(samplePath),
+      ]);
+      await page.locator("#cell-dialog").waitFor({ state: "hidden" });
+      await idle("replacement allowed after authoritative edit settles");
+      assert.equal(await page.locator("#error-banner").isHidden(), true);
+    }
+    console.log(
+      "PASS dialog drafts/discard/save guard, 4 stale save responses, and 2 authoritative edit replacement guards",
+    );
+  } finally {
+    page.off("download", onDownload);
+  }
+}
+
+async function installDelays(page, command, outcome) {
+  await page.evaluate(
+    async ({ command, outcome }) => {
+      const { RenderWorkerClient } = await import(
+        new URL("runtime/js/client.mjs", document.baseURI).href
+      );
+      const prototype = RenderWorkerClient.prototype;
+      const method =
+        command === "save" ? "saveDocument" : "setCellAndRecalculate";
+      const originalOperation = prototype[method];
+      const originalOpen = prototype.open;
+      let releaseOperation;
+      let releaseOpen;
+      const operationGate = new Promise((resolve) => {
+        releaseOperation = resolve;
+      });
+      const openGate = new Promise((resolve) => {
+        releaseOpen = resolve;
+      });
+      const guard = (globalThis.__rxlsEditingGuards = {
+        captured: false,
+        openStarted: false,
+        finished: false,
+        releaseOperation,
+        releaseOpen,
+        restore() {
+          prototype[method] = originalOperation;
+          prototype.open = originalOpen;
+          releaseOperation();
+          releaseOpen();
+          delete globalThis.__rxlsEditingGuards;
+        },
+      });
+      prototype[method] = async function (...args) {
+        const result =
+          command === "cell" && outcome === "reject"
+            ? null
+            : await originalOperation.apply(this, args);
+        guard.captured = true;
+        await operationGate;
+        try {
+          if (outcome === "reject")
+            throw new Error("Obsolete editing guard response");
+          return result;
+        } finally {
+          guard.finished = true;
+        }
+      };
+      prototype.open = async function (...args) {
+        guard.openStarted = true;
+        await openGate;
+        return originalOpen.apply(this, args);
+      };
+    },
+    { command, outcome },
+  );
+}

--- a/viewer/tests/editing.test.mjs
+++ b/viewer/tests/editing.test.mjs
@@ -45,6 +45,7 @@ function setup({
   client = {},
   beforeCommand,
   renderCurrent,
+  confirmResult = false,
 } = {}) {
   const elements = new Proxy(
     {},
@@ -72,6 +73,7 @@ function setup({
     sheetIndex: 0,
     pageIndex: 3,
     busy: false,
+    openGeneration: 0,
     manifests: new Map([[0, { pages: [1] }]]),
     file: { name: "Quarter.xlsm", size: 100, source: "Local file" },
   };
@@ -104,7 +106,7 @@ function setup({
     download: (blob, name) => calls.downloads.push({ blob, name }),
     confirm: (message) => {
       calls.confirms.push(message);
-      return false;
+      return confirmResult;
     },
   });
   elements["cell-reference"].value = "A1";
@@ -113,6 +115,362 @@ function setup({
 }
 
 const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+const readNumber = async () => ({ value: { kind: "number", value: 4 } });
+
+test("every unapplied dialog field participates in discard checks without counting untouched dialogs", async () => {
+  for (const [dialog, fields] of [
+    [
+      "cell",
+      [
+        "cell-reference",
+        "cell-kind",
+        "cell-value",
+        "cell-formula",
+        "cell-cached-kind",
+        "cell-cached-value",
+      ],
+    ],
+    [
+      "properties",
+      [
+        "property-title",
+        "property-subject",
+        "property-creator",
+        "property-keywords",
+        "property-description",
+        "property-last-modified-by",
+        "property-company",
+        "property-created",
+      ],
+    ],
+  ]) {
+    for (const field of fields) {
+      const { controller, elements, calls } = setup({
+        client: { readCell: readNumber },
+      });
+      await (dialog === "cell"
+        ? controller.openCellEditor()
+        : controller.openPropertiesEditor());
+      assert.equal(controller.hasDraftChanges(), false, `${field}: untouched`);
+      const original = elements[field].value;
+      elements[field].value = "invalid unapplied draft";
+      assert.equal(controller.hasDraftChanges(), true, field);
+      assert.equal(controller.confirmDiscardChanges(), false, field);
+      assert.equal(elements[field].value, "invalid unapplied draft", field);
+      assert.equal(calls.confirms.length, 1, field);
+      elements[field].value = original;
+      assert.equal(controller.hasDraftChanges(), false, `${field}: reverted`);
+    }
+  }
+});
+
+test("Cancel and Escape explicitly discard dialog drafts; reopening starts clean", async () => {
+  const { controller, elements } = setup({ client: { readCell: readNumber } });
+  for (const kind of ["cell", "properties"]) {
+    const open =
+      kind === "cell"
+        ? controller.openCellEditor
+        : controller.openPropertiesEditor;
+    const field = kind === "cell" ? "cell-value" : "property-title";
+    for (const action of ["button", "escape"]) {
+      await open();
+      elements[field].value = "draft";
+      if (action === "button") elements[`cancel-${kind}-edit`].emit("click");
+      else elements[`${kind}-dialog`].emit("cancel");
+      assert.equal(elements[`${kind}-dialog`].open, false);
+      assert.equal(controller.hasDraftChanges(), false);
+      await open();
+      assert.notEqual(elements[field].value, "draft");
+      assert.equal(controller.hasDraftChanges(), false);
+    }
+    (kind === "cell"
+      ? controller.closeCellEditor
+      : controller.closePropertiesEditor)();
+  }
+});
+
+test("save refuses unapplied invalid dialog fields without submitting or losing them", async () => {
+  let saves = 0;
+  const { controller, elements, calls } = setup({
+    client: {
+      readCell: readNumber,
+      saveDocument: async () => {
+        saves++;
+        return { bytes: new Uint8Array([1]) };
+      },
+    },
+  });
+  await controller.openCellEditor();
+  elements["cell-value"].value = "not a number";
+  await controller.saveWorkbookCopy();
+  assert.equal(saves, 0);
+  assert.match(calls.errors.at(-1).message, /Apply or Cancel/);
+  assert.equal(elements["cell-value"].value, "not a number");
+  controller.closeCellEditor();
+  await controller.openPropertiesEditor();
+  elements["property-created"].value = "invalid date";
+  await controller.saveWorkbookCopy();
+  assert.equal(saves, 0);
+  controller.closePropertiesEditor();
+  await controller.saveWorkbookCopy();
+  assert.equal(saves, 1);
+});
+
+test("changing the cell address or rereading cannot silently erase a value draft", async () => {
+  let reads = 0;
+  const { controller, elements, calls } = setup({
+    client: {
+      readCell: async () => {
+        reads++;
+        return readNumber();
+      },
+    },
+  });
+  await controller.openCellEditor();
+  elements["cell-value"].value = "draft";
+  elements["cell-reference"].value = "B2";
+  elements["cell-reference"].emit("input");
+  elements["cell-reference"].emit("change");
+  await flush();
+  assert.equal(reads, 1);
+  assert.equal(elements["cell-value"].value, "draft");
+  assert.equal(calls.confirms.length, 1);
+  assert.equal(elements["apply-cell-edit"].disabled, true);
+  elements["cell-reference"].value = "A1";
+  elements["cell-reference"].emit("input");
+  assert.equal(elements["apply-cell-edit"].disabled, false);
+});
+
+test("accepted discard allows loading a different cell and establishes a clean baseline", async () => {
+  const { controller, elements } = setup({
+    client: { readCell: readNumber },
+    confirmResult: true,
+  });
+  await controller.openCellEditor();
+  elements["cell-value"].value = "draft";
+  assert.equal(controller.confirmDiscardChanges(), true);
+  elements["cell-reference"].value = "B2";
+  elements["cell-reference"].emit("input");
+  elements["cell-reference"].emit("change");
+  await flush();
+  assert.equal(elements["cell-value"].value, "4");
+  assert.equal(controller.hasDraftChanges(), false);
+});
+
+for (const outcome of ["resolve", "reject"]) {
+  for (const replace of [false, true]) {
+    test(`save ${outcome} cannot affect a ${replace ? "replaced" : "pending-open"} workbook`, async () => {
+      const pending = deferred();
+      const { controller, state, calls, elements } = setup({
+        client: { saveDocument: () => pending.promise },
+      });
+      const saved = controller.saveWorkbookCopy();
+      state.openGeneration++;
+      if (replace) {
+        state.client = {};
+        state.documentId = "replacement";
+        state.file.name = "New.xlsx";
+      }
+      state.busy = true;
+      elements["status-message"].textContent = "Opening replacement";
+      if (outcome === "resolve")
+        pending.resolve({ bytes: new Uint8Array([1]) });
+      else pending.reject(new Error("Old client closed"));
+      await saved;
+      assert.equal(state.busy, true);
+      assert.deepEqual(calls.errors, []);
+      assert.deepEqual(calls.downloads, []);
+      assert.equal(
+        elements["status-message"].textContent,
+        "Opening replacement",
+      );
+    });
+  }
+  test(`cell-submit ${outcome} cannot affect a pending open or its new dialog`, async () => {
+    const pending = deferred();
+    const fixture = setup({
+      client: { readCell: readNumber, setCell: () => pending.promise },
+    });
+    const { controller, state, calls, elements } = fixture;
+    await controller.openCellEditor();
+    elements["cell-value"].value = "9";
+    elements["cell-form"].emit("submit");
+    state.openGeneration++;
+    controller.closeCellEditor();
+    state.busy = false;
+    await controller.openPropertiesEditor();
+    elements["property-title"].value = "Replacement draft";
+    state.busy = true;
+    if (outcome === "resolve")
+      pending.resolve({
+        workbook: fixture.workbook,
+        editState: { capability: "read-write", dirty: true },
+      });
+    else pending.reject(new Error("Old client closed"));
+    await flush();
+    assert.equal(state.busy, true);
+    assert.deepEqual(calls.errors, []);
+    assert.equal(calls.updates, 0);
+    assert.equal(elements["properties-dialog"].open, true);
+    assert.equal(elements["property-title"].value, "Replacement draft");
+  });
+}
+
+test("an open beginning during beforeCommand cancels the suspended command", async () => {
+  const gate = deferred();
+  let saves = 0;
+  const { controller, state } = setup({
+    beforeCommand: () => gate.promise,
+    client: {
+      saveDocument: async () => {
+        saves++;
+        return { bytes: new Uint8Array() };
+      },
+    },
+  });
+  const pending = controller.saveWorkbookCopy();
+  state.openGeneration++;
+  gate.resolve(true);
+  await pending;
+  assert.equal(saves, 0);
+});
+
+test("range commits share the one-mutation render, history, and warning path", async () => {
+  const fixture = setup();
+  const requests = [];
+  fixture.state.client.setRangeAndRecalculate = async (...args) => {
+    requests.push(args);
+    return {
+      workbook: fixture.workbook,
+      editState: {
+        capability: "read-write",
+        dirty: true,
+        undoDepth: 1,
+        redoDepth: 0,
+      },
+      recalculation: {
+        computedCells: 1,
+        unchangedCells: 0,
+        unsupportedCells: 1,
+      },
+    };
+  };
+  const values = [
+    [
+      { kind: "number", value: 7 },
+      { kind: "formula-auto", formula: "=A1+1" },
+    ],
+  ];
+  assert.equal(
+    await fixture.controller.commitRangeEdit(
+      {
+        client: fixture.state.client,
+        documentId: fixture.state.documentId,
+        sheetIndex: 0,
+        row: 0,
+        col: 0,
+      },
+      values,
+    ),
+    true,
+  );
+  assert.deepEqual(requests, [["document-one", 0, 0, 0, values]]);
+  assert.equal(fixture.calls.renders.length, 1);
+  assert.equal(fixture.state.pageIndex, 3);
+  assert.equal(fixture.state.editState.undoDepth, 1);
+  assert.match(
+    fixture.elements["status-message"].textContent,
+    /unsupported formula/,
+  );
+});
+
+test("stale operation cleanup cannot unlock a newer properties submission", async () => {
+  const old = deferred();
+  const current = deferred();
+  const fixture = setup({
+    client: { setDocumentProperties: () => old.promise },
+  });
+  const { controller, state, elements, calls } = fixture;
+  const buttons = [control(), control()];
+  elements["properties-form"].querySelectorAll = () => buttons;
+  await controller.openPropertiesEditor();
+  elements["properties-form"].emit("submit");
+  state.openGeneration++;
+  controller.closePropertiesEditor();
+  state.busy = false;
+  state.client = { setDocumentProperties: () => current.promise };
+  await controller.openPropertiesEditor();
+  elements["properties-form"].emit("submit");
+  old.reject(new Error("old client closed"));
+  await flush();
+  assert.equal(state.busy, true);
+  assert.ok(buttons.every((button) => button.disabled));
+  assert.deepEqual(calls.errors, []);
+  current.resolve({
+    workbook: fixture.workbook,
+    editState: { capability: "read-write", dirty: true },
+  });
+  await flush();
+  assert.equal(state.busy, false);
+  assert.ok(buttons.every((button) => !button.disabled));
+});
+
+test("a new open generation ignores read failures before document identity changes", async () => {
+  const pending = deferred();
+  const { controller, state, calls } = setup({
+    client: { readCell: () => pending.promise },
+  });
+  const opened = controller.openCellEditor();
+  state.openGeneration++;
+  pending.reject(new Error("stale read"));
+  await opened;
+  assert.deepEqual(calls.errors, []);
+});
+
+test("pending mutation reporting includes history but excludes saves and obsolete generations", async () => {
+  for (const direction of ["undo", "redo"]) {
+    const pending = deferred();
+    const fixture = setup({
+      client: { [`${direction}Edit`]: () => pending.promise },
+    });
+    const { controller, state } = fixture;
+    assert.equal(controller.hasPendingMutation(), false);
+    const editing = controller.applyHistoryEdit(direction);
+    assert.equal(controller.hasPendingMutation(), true);
+    state.openGeneration++;
+    assert.equal(controller.hasPendingMutation(), false);
+    pending.resolve({ workbook: fixture.workbook, editState: state.editState });
+    await editing;
+    assert.equal(controller.hasPendingMutation(), false);
+  }
+  const pending = deferred();
+  const { controller } = setup({
+    client: { saveDocument: () => pending.promise },
+  });
+  const saving = controller.saveWorkbookCopy();
+  assert.equal(
+    controller.hasPendingMutation(),
+    false,
+    "read-only serialization may be superseded by opening",
+  );
+  pending.resolve({ bytes: new Uint8Array([1]) });
+  await saving;
+});
+
+test("current history failures always release the authoritative mutation guard", async () => {
+  const pending = deferred();
+  const { controller, state, calls } = setup({
+    client: { undoEdit: () => pending.promise },
+  });
+  const undo = controller.applyHistoryEdit("undo");
+  assert.equal(controller.hasPendingMutation(), true);
+  pending.reject(new Error("undo rejected"));
+  await undo;
+  assert.equal(controller.hasPendingMutation(), false);
+  assert.equal(state.busy, false);
+  assert.equal(calls.errors.length, 1);
+});
 
 test("editing UI is safe before loading a workbook and stays read-only in VS Code", async () => {
   const fixture = setup({ readOnly: true });
@@ -349,6 +707,10 @@ test("shared cell commit requires the current bounded editable target", async ()
   );
   await assert.rejects(
     controller.commitCellEdit({ ...target, row: -1 }, { kind: "blank" }),
+    /grid/,
+  );
+  await assert.rejects(
+    controller.commitCellEdit({ ...target, col: Infinity }, { kind: "blank" }),
     /grid/,
   );
   state.busy = true;

--- a/viewer/tests/grid-editor.test.mjs
+++ b/viewer/tests/grid-editor.test.mjs
@@ -1,176 +1,107 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import {
-  createGridEditor,
-  gridCells,
-  gridPointer,
-  inlineCellValue,
-} from "../src/grid-editor.js";
+import { gridCells, gridPointer, inlineCellValue } from "../src/grid-editor.js";
 
-const interaction = {
-  schemaVersion: 1,
-  width: 150,
-  height: 40,
-  cells: [
-    [0, 0, 0, 0, 100, 20],
-    [0, 2, 100, 0, 50, 20],
-    [2, 0, 0, 20, 50, 20],
-    [2, 2, 100, 20, 50, 20],
-  ],
-};
-const flush = () => new Promise((resolve) => setImmediate(resolve));
-function deferred() {
-  let resolve;
-  let reject;
-  const promise = new Promise((yes, no) => {
-    resolve = yes;
-    reject = no;
-  });
-  return { promise, resolve, reject };
-}
-function element() {
-  const listeners = new Map();
-  const classes = new Set();
-  const attrs = new Map();
-  let value = "";
-  let disabled = false;
-  return {
-    get value() {
-      return value;
-    },
-    set value(next) {
-      value = String(next).replace(/\r\n?/g, "\n");
-    },
-    hidden: true,
-    get disabled() {
-      return disabled;
-    },
-    set disabled(next) {
-      disabled = Boolean(next);
-      if (disabled && this.ownerDocument?.activeElement === this)
-        this.ownerDocument.activeElement = this.ownerDocument.body;
-    },
-    style: {},
-    dataset: {},
-    parentElement: null,
-    classList: {
-      contains: (name) => classes.has(name),
-      toggle(name, value) {
-        if (value) classes.add(name);
-        else classes.delete(name);
-      },
-    },
-    addEventListener(type, listener) {
-      listeners.set(type, listener);
-    },
-    async fire(type, details = {}) {
-      const event = {
-        target: this,
-        prevented: false,
-        stopped: false,
-        preventDefault() {
-          this.prevented = true;
-        },
-        stopPropagation() {
-          this.stopped = true;
-        },
-        ...details,
-      };
-      await listeners.get(type)?.(event);
-      await flush();
-      return event;
-    },
-    append(child) {
-      child.parentElement = this;
-    },
-    setAttribute(name, value) {
-      attrs.set(name, value);
-    },
-    getAttribute: (name) => attrs.get(name),
-    focus() {
-      if (this.disabled) return;
-      this.focused = true;
-      if (this.ownerDocument) this.ownerDocument.activeElement = this;
-    },
-    setSelectionRange(start, end) {
-      this.selectionStart = start;
-      this.selectionEnd = end;
-    },
-    getBoundingClientRect: () => ({ left: 100, top: 50 }),
-  };
-}
-function setup({ readOnly = false, readCell, commitCellEdit, focusOutsideGrid } = {}) {
-  const calls = { reads: [], commits: [], selections: [], errors: [], exits: [] };
-  const exitTargets = { previous: element(), next: element() };
-  const elements = Object.fromEntries(
-    [
-      "document-surface",
-      "grid-layer",
-      "grid-selection",
-      "grid-input",
-      "grid-status",
-    ].map((id) => [id, element()]),
-  );
-  const svg = {
-    getScreenCTM: () => ({
-      a: 2,
-      b: 0,
-      c: 0,
-      d: 2,
-      e: 100,
-      f: 50,
-      inverse: () => ({ a: 0.5, b: 0, c: 0, d: 0.5, e: -50, f: -25 }),
-    }),
-  };
-  const state = {
-    mode: "sheet",
-    busy: false,
-    documentId: "one",
-    sheetIndex: 0,
-    workbook: { sheetCount: 1 },
-    editState: { capability: "read-write" },
-    client: {
-      readCell: async (...args) => {
-        calls.reads.push(args);
-        return readCell
-          ? readCell(...args)
-          : { value: { kind: "number", value: 10 }, formatted: "10" };
-      },
-    },
-  };
-  const grid = createGridEditor({
-    state,
-    elements,
-    readOnly,
-    editing: {
-      commitCellEdit: async (...args) => {
-        calls.commits.push(args);
-        return commitCellEdit ? commitCellEdit(...args) : true;
-      },
-    },
-    onSelection: (value) => calls.selections.push(value),
-    focusOutsideGrid: (direction) => {
-      calls.exits.push(direction);
-      if (focusOutsideGrid) return focusOutsideGrid(direction);
-      exitTargets[direction].focus();
+import {
+  setup,
+  element,
+  deferred,
+  flush,
+  interaction,
+} from "./support/grid-editor.mjs";
+
+test("range paste keeps the draft on failure and clears it only after one successful transaction", async () => {
+  let fail = true;
+  const env = setup({
+    commitRangeEdit: async () => {
+      if (fail) throw new Error("Merged cell interior");
       return true;
     },
-    showError: (error) => calls.errors.push(error),
   });
-  grid.mount(interaction, svg);
-  return {
-    grid,
-    state,
-    calls,
-    elements,
-    svg,
-    exitTargets,
-    input: elements["grid-input"],
-    outline: elements["grid-selection"],
-    layer: elements["grid-layer"],
-    surface: elements["document-surface"],
-  };
-}
+  await flush();
+  await env.grid.beginEdit("original draft");
+  const target = env.grid.getPasteTarget();
+  const values = [[{ kind: "number", value: 2 }, { kind: "blank" }]];
+  assert.equal(await env.grid.applyRange(target, values), false);
+  assert.equal(env.input.value, "original draft");
+  assert.equal(env.grid.hasChanges(), true);
+  assert.equal(env.calls.commits.length, 0);
+  fail = false;
+  assert.equal(await env.grid.applyRange(target, values), true);
+  assert.equal(env.grid.hasDraft(), false);
+  assert.equal(env.calls.ranges.length, 2);
+  assert.deepEqual(env.calls.ranges[1][1], values);
+});
+
+test("range paste is unavailable in read-only, busy, IME and stale-open contexts", async () => {
+  assert.equal(setup({ readOnly: true }).grid.getPasteTarget(), null);
+  const env = setup();
+  await flush();
+  const target = env.grid.getPasteTarget();
+  env.state.openGeneration = 1;
+  assert.equal(await env.grid.applyRange(target, [[{ kind: "blank" }]]), false);
+  assert.equal(env.calls.ranges.length, 0);
+  env.state.busy = true;
+  assert.equal(env.grid.getPasteTarget(), null);
+  env.state.busy = false;
+  await env.input.fire("compositionstart");
+  assert.equal(env.grid.getPasteTarget(), null);
+});
+
+test("a late range completion cannot clear a draft or focus a replacement workbook", async () => {
+  const pending = deferred();
+  const env = setup({ commitRangeEdit: () => pending.promise });
+  await flush();
+  await env.grid.beginEdit("keep me");
+  const applying = env.grid.applyRange(env.grid.getPasteTarget(), [
+    [{ kind: "blank" }],
+  ]);
+  env.state.openGeneration = 1;
+  pending.resolve(true);
+  assert.equal(await applying, false);
+  assert.equal(env.input.value, "keep me");
+  assert.equal(env.grid.hasChanges(), true);
+});
+
+test("large-grid selection and Tab avoid linear lookup and arrows avoid candidate sorting", async () => {
+  const env = setup();
+  const cells = Array.from({ length: 10_000 }, (_, i) => [
+    Math.floor(i / 100),
+    i % 100,
+    (i % 100) * 50,
+    Math.floor(i / 100) * 20,
+    50,
+    20,
+  ]);
+  env.grid.mount(
+    { schemaVersion: 1, width: 5000, height: 2000, cells },
+    env.svg,
+  );
+  await flush();
+  assert.equal(await env.grid.select("50", 50), false);
+  const originals = Object.fromEntries(
+    ["find", "findIndex", "filter", "sort"].map((key) => [
+      key,
+      Array.prototype[key],
+    ]),
+  );
+  const scans = [];
+  try {
+    for (const [key, original] of Object.entries(originals))
+      Array.prototype[key] = function (...args) {
+        if (this.length >= 100 && this[0]?.reference) scans.push(key);
+        return Reflect.apply(original, this, args);
+      };
+    await env.grid.select(50, 50);
+    await env.input.fire("keydown", { key: "Tab" });
+    await env.input.fire("keydown", { key: "ArrowDown" });
+    assert.equal(env.outline.dataset.reference, "AZ52");
+    assert.deepEqual(scans, []);
+  } finally {
+    for (const [key, original] of Object.entries(originals))
+      Array.prototype[key] = original;
+  }
+});
 
 test("inline values preserve text intent and date serials without fabricating formula caches", () => {
   for (const [text, expected] of [
@@ -453,7 +384,11 @@ test("edge Tab waits for its own async commit and remount before moving focus", 
     await fixture.grid.select(row, col);
     await fixture.grid.beginEdit("77");
     const event = await fixture.input.fire("keydown", { key: "Tab", shiftKey });
-    assert.equal(event.prevented, true, "default is cancelled before the async write");
+    assert.equal(
+      event.prevented,
+      true,
+      "default is cancelled before the async write",
+    );
     assert.deepEqual(fixture.calls.exits, []);
     assert.equal(fixture.grid.hasDraft(), true);
     pending.resolve(true);
@@ -491,7 +426,9 @@ test("failed keyboard commits restore the retained draft after disabling blurs t
   for (const key of ["Tab", "Enter"]) {
     for (const outcome of ["failed", "rejected"]) {
       const pending = deferred();
-      const { grid, input, calls } = setup({ commitCellEdit: () => pending.promise });
+      const { grid, input, calls } = setup({
+        commitCellEdit: () => pending.promise,
+      });
       const document = { activeElement: null, body: element() };
       input.ownerDocument = document;
       await grid.select(2, 2);
@@ -500,7 +437,8 @@ test("failed keyboard commits restore the retained draft after disabling blurs t
       await input.fire("keydown", { key });
       assert.equal(input.disabled, true);
       assert.equal(document.activeElement, document.body);
-      if (outcome === "failed") pending.reject(new Error("Unsupported formula"));
+      if (outcome === "failed")
+        pending.reject(new Error("Unsupported formula"));
       else pending.resolve(false);
       await flush();
       assert.equal(input.disabled, false);
@@ -515,7 +453,9 @@ test("failed keyboard commits restore the retained draft after disabling blurs t
 test("failed commits never steal focus after a user focus move or workbook change", async () => {
   for (const outcome of ["other-control", "stale", "toolbar"]) {
     const pending = deferred();
-    const { grid, state, input } = setup({ commitCellEdit: () => pending.promise });
+    const { grid, state, input } = setup({
+      commitCellEdit: () => pending.promise,
+    });
     const document = { activeElement: null, body: element() };
     input.ownerDocument = document;
     await grid.select(2, 2);
@@ -527,7 +467,10 @@ test("failed commits never steal focus after a user focus move or workbook chang
     if (outcome === "stale") state.documentId = "another workbook";
     pending.resolve(false);
     assert.equal(await committing, false);
-    assert.equal(document.activeElement, outcome === "stale" ? document.body : otherControl);
+    assert.equal(
+      document.activeElement,
+      outcome === "stale" ? document.body : otherControl,
+    );
     assert.equal(grid.hasDraft(), true);
     assert.equal(input.value, "77");
   }
@@ -536,7 +479,10 @@ test("failed commits never steal focus after a user focus move or workbook chang
 test("edge Tab can exit when its committed blank removes the last rendered cell", async () => {
   const fixture = setup({
     commitCellEdit: async () => {
-      fixture.grid.mount({ ...interaction, cells: interaction.cells.slice(0, 1) }, fixture.svg);
+      fixture.grid.mount(
+        { ...interaction, cells: interaction.cells.slice(0, 1) },
+        fixture.svg,
+      );
       return true;
     },
   });
@@ -564,7 +510,9 @@ test("edge Tab preserves selection when no outside target can accept focus", asy
 
 test("a successful edge commit does not steal focus from another control", async () => {
   const pending = deferred();
-  const { grid, input, calls } = setup({ commitCellEdit: () => pending.promise });
+  const { grid, input, calls } = setup({
+    commitCellEdit: () => pending.promise,
+  });
   const document = { activeElement: input, body: element() };
   input.ownerDocument = document;
   await grid.select(2, 2);

--- a/viewer/tests/grid-generation.test.mjs
+++ b/viewer/tests/grid-generation.test.mjs
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { setup, deferred, flush } from "./support/grid-editor.mjs";
+
+for (const outcome of ["resolve", "reject"]) {
+  test(`a stale one-click read ${outcome} cannot announce over a newer open`, async () => {
+    const pending = deferred();
+    const { grid, state, calls, elements } = setup({
+      readCell: () => pending.promise,
+    });
+    const editing = grid.beginEdit();
+    state.openGeneration = 1;
+    state.busy = true;
+    elements["grid-status"].textContent = "Opening replacement";
+    if (outcome === "resolve")
+      pending.resolve({ value: { kind: "number", value: 10 } });
+    else pending.reject(new Error("Old read failed"));
+    assert.equal(await editing, false);
+    assert.equal(elements["grid-status"].textContent, "Opening replacement");
+    assert.deepEqual(calls.errors, []);
+  });
+
+  test(`a stale grid mutation ${outcome} cannot clear the draft or report an obsolete failure`, async () => {
+    const pending = deferred();
+    const { grid, state, input, calls, elements } = setup({
+      commitCellEdit: () => pending.promise,
+    });
+    await flush();
+    await grid.beginEdit();
+    input.value = "7";
+    await input.fire("input");
+    const committing = grid.commit();
+    state.openGeneration = 1;
+    state.busy = true;
+    elements["grid-status"].textContent = "Opening replacement";
+    if (outcome === "resolve") pending.resolve(true);
+    else pending.reject(new Error("Old write failed"));
+    assert.equal(await committing, false);
+    assert.equal(input.value, "7");
+    assert.equal(grid.hasChanges(), true);
+    assert.equal(elements["grid-status"].textContent, "Opening replacement");
+    assert.deepEqual(calls.errors, []);
+  });
+}

--- a/viewer/tests/range-paste.mjs
+++ b/viewer/tests/range-paste.mjs
@@ -1,0 +1,378 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+import { createStoredZip, readZipEntries } from "../scripts/zip.mjs";
+
+export async function exerciseRangePaste(
+  page,
+  {
+    waitForCondition,
+    waitForViewerState,
+    downloadWorkbook,
+    assertOpenpyxlReopens,
+  },
+) {
+  const input = page.locator("#grid-input");
+  const dialog = page.locator("#paste-dialog");
+  const select = async (reference, expected) => {
+    await page.locator("#inspector-reference").fill(reference);
+    await page.locator("#inspector-reference").press("Enter");
+    await waitForCondition(
+      async () =>
+        (await page
+          .locator("#grid-selection")
+          .getAttribute("data-reference")) === reference &&
+        !(await input.isDisabled()) &&
+        (expected === undefined ||
+          (await page.locator("#inspector-value").inputValue()) === expected),
+      `paste target ${reference}`,
+    );
+  };
+  const paste = async (text) => {
+    await input.focus();
+    return input.evaluate((element, value) => {
+      const data = new DataTransfer();
+      data.setData("text/plain", value);
+      const event = new ClipboardEvent("paste", {
+        clipboardData: data,
+        bubbles: true,
+        cancelable: true,
+      });
+      element.dispatchEvent(event);
+      return event.defaultPrevented;
+    }, text);
+  };
+  const undo = async () => {
+    await page.locator("#undo-edit").click();
+    await waitForViewerState(
+      page,
+      (state) => !state.busy && !state.dirty,
+      "one range undo restores source",
+    );
+  };
+
+  await select("C4", "420000");
+  await input.press("F2");
+  await input.fill("retained draft");
+  assert.equal(await paste("1\t2"), true);
+  await dialog.waitFor({ state: "visible" });
+  await page.keyboard.press("Escape");
+  await dialog.waitFor({ state: "hidden" });
+  assert.equal(
+    await input.inputValue(),
+    "retained draft",
+    "Escape only cancels the preview",
+  );
+  await input.press("Escape");
+
+  const clipboard = '125000\t=C4*2\r\n200000\t"two\tparts\r\nnext line"\r\n';
+  assert.equal(await paste(clipboard), true);
+  assert.match(
+    await page.locator("#paste-summary").textContent(),
+    /C4:D5.*2 rows.*2 columns.*4 cells/,
+  );
+  assert.equal(await page.locator("#paste-preview td").count(), 4);
+  assert.equal(
+    await page.locator("#paste-preview td").last().textContent(),
+    "two\tparts\nnext line",
+  );
+  if (process.env.RXLS_VIEWER_SCREENSHOTS === "1") {
+    await mkdir(new URL("../../target/viewer-e2e/", import.meta.url), {
+      recursive: true,
+    });
+    await page.screenshot({
+      path: fileURLToPath(
+        new URL("../../target/viewer-e2e/range-paste.png", import.meta.url),
+      ),
+    });
+  }
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mobile = await dialog.boundingBox();
+  assert.ok(
+    mobile &&
+      mobile.x >= 0 &&
+      mobile.y >= 0 &&
+      mobile.x + mobile.width <= 391 &&
+      mobile.y + mobile.height <= 845,
+    "range preview fits a mobile viewport",
+  );
+  for (const id of ["cancel-range-paste", "paste-as-text", "apply-range-paste"])
+    assert.equal(await page.locator(`#${id}`).isVisible(), true);
+  if (process.env.RXLS_VIEWER_SCREENSHOTS === "1")
+    await page.screenshot({
+      path: fileURLToPath(
+        new URL(
+          "../../target/viewer-e2e/mobile-range-paste.png",
+          import.meta.url,
+        ),
+      ),
+    });
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.keyboard.press(
+    process.platform === "darwin" ? "Meta+s" : "Control+s",
+  );
+  assert.match(
+    await page.locator("#paste-status").textContent(),
+    /Apply or cancel/,
+  );
+  assert.equal(
+    (await page.evaluate(() => globalThis.__rxlsViewerState())).dirty,
+    false,
+  );
+  await page.locator("#apply-range-paste").click();
+  await dialog.waitFor({ state: "hidden" });
+  await waitForViewerState(
+    page,
+    (state) => !state.busy && state.dirty,
+    "rectangular paste applied",
+  );
+  await select("C4", "125000");
+  await select("D4", "=C4*2");
+  await select("C5", "200000");
+  await select("D5", "two\tparts\nnext line");
+  const saved = await downloadWorkbook(page, ".xlsx");
+  await assertOpenpyxlReopens(saved.path, {
+    expected: "Q3 Operations Snapshot",
+    cacheCell: "C10",
+    expectedCache: 1094000,
+  });
+  await undo();
+  await select("C4", "420000");
+  await select("C5", "185000");
+  await page.locator("#redo-edit").click();
+  await waitForViewerState(
+    page,
+    (state) => !state.busy && state.dirty,
+    "range redo",
+  );
+  await select("C4", "125000");
+  await select("D5", "two\tparts\nnext line");
+  await undo();
+
+  // Merged interiors reject the whole batch, including the valid anchor.
+  await select("A1", "Q3 Operations Snapshot");
+  await input.press("F2");
+  await input.fill("keep this draft");
+  await paste("new heading\tmerged interior");
+  await page.locator("#apply-range-paste").click();
+  await waitForCondition(
+    async () => !(await page.locator("#cancel-range-paste").isDisabled()),
+    "failed paste settled",
+  );
+  assert.match(
+    await page.locator("#paste-status").textContent(),
+    /not applied/,
+  );
+  assert.equal(
+    (await page.evaluate(() => globalThis.__rxlsViewerState())).dirty,
+    false,
+  );
+  await page.locator("#cancel-range-paste").click();
+  assert.equal(await input.inputValue(), "keep this draft");
+  await input.press("Escape");
+  await page.locator("#dismiss-error").click();
+  await select("C4", "420000");
+
+  // Invalid rectangles cannot partially write; users can intentionally keep multiline text.
+  await paste("a\tb\nc");
+  assert.equal(await page.locator("#apply-range-paste").isDisabled(), true);
+  await page.locator("#paste-as-text").click();
+  await dialog.waitFor({ state: "hidden" });
+  await waitForViewerState(
+    page,
+    (state) => !state.busy && state.dirty,
+    "explicit one-cell text paste",
+  );
+  await select("C4", "a\tb\nc");
+  await undo();
+  await select("C4", "420000");
+  await paste("=UNKNOWNFUNCTION(1)\t2");
+  await page.locator("#apply-range-paste").click();
+  await waitForCondition(
+    async () => !(await page.locator("#cancel-range-paste").isDisabled()),
+    "unsupported formula paste settled",
+  );
+  assert.equal(
+    (await page.evaluate(() => globalThis.__rxlsViewerState())).dirty,
+    false,
+  );
+  await page.locator("#cancel-range-paste").click();
+  await page.locator("#dismiss-error").click();
+
+  await page.locator("#page-view").click();
+  await waitForViewerState(
+    page,
+    (state) => !state.busy && state.mode === "page",
+    "paste disabled in page view",
+  );
+  const pagePastePrevented = await page
+    .locator("#document-surface")
+    .evaluate((element) => {
+      const data = new DataTransfer();
+      data.setData("text/plain", "1\t2");
+      const event = new ClipboardEvent("paste", {
+        clipboardData: data,
+        bubbles: true,
+        cancelable: true,
+      });
+      element.dispatchEvent(event);
+      return event.defaultPrevented;
+    });
+  assert.equal(pagePastePrevented, false);
+  assert.equal(await dialog.isHidden(), true);
+  await page.locator("#sheet-view").click();
+  await waitForViewerState(
+    page,
+    (state) => !state.busy && state.mode === "sheet",
+    "paste sheet restored",
+  );
+  await select("A1", "Q3 Operations Snapshot");
+}
+
+export async function exerciseLargeRangePaste(
+  page,
+  {
+    waitForCondition,
+    waitForViewerState,
+    downloadWorkbook,
+    assertOpenpyxlReopens,
+  },
+) {
+  const sample = new URL("../samples/operations-report.xlsx", import.meta.url);
+  const entries = readZipEntries(await readFile(sample));
+  const data = Array.from(
+    { length: 1000 },
+    (_, row) =>
+      `<row r="${row + 1}">${Array.from({ length: 16 }, (_, col) => `<c r="${String.fromCharCode(65 + col)}${row + 1}"><v>1</v></c>`).join("")}</row>`,
+  ).join("");
+  entries.set(
+    "xl/worksheets/sheet1.xml",
+    Buffer.from(
+      `<?xml version="1.0" encoding="UTF-8"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>${data}<row r="1001"><c r="P1001"><f>SUM(A1:A1000)</f><v>1000</v></c></row></sheetData></worksheet>`,
+    ),
+  );
+  await page.locator("#file-input").setInputFiles({
+    name: "large-range.xlsx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    buffer: createStoredZip(
+      [...entries].map(([name, data]) => ({ name, data })),
+    ),
+  });
+  await waitForViewerState(
+    page,
+    (state) =>
+      state.fileName === "large-range.xlsx" && !state.busy && state.rendered,
+    "16,001-cell interactive workbook",
+  );
+  await page.locator("#inspector-reference").fill("A1");
+  await page.locator("#inspector-reference").press("Enter");
+  await waitForCondition(
+    async () =>
+      (await page.locator("#grid-selection").getAttribute("data-reference")) ===
+        "A1" && !(await page.locator("#grid-input").isDisabled()),
+    "large range anchor",
+  );
+  await page.evaluate(async () => {
+    const { RenderWorkerClient } = await import(
+      new URL("runtime/js/client.mjs", document.baseURI).href
+    );
+    const original = RenderWorkerClient.prototype.setRangeAndRecalculate;
+    globalThis.__rangeTiming = {
+      calls: 0,
+      workerMs: 0,
+      restore: () => {
+        RenderWorkerClient.prototype.setRangeAndRecalculate = original;
+      },
+    };
+    RenderWorkerClient.prototype.setRangeAndRecalculate = async function (
+      ...args
+    ) {
+      globalThis.__rangeTiming.calls++;
+      const start = performance.now();
+      try {
+        return await original.apply(this, args);
+      } finally {
+        globalThis.__rangeTiming.workerMs += performance.now() - start;
+      }
+    };
+  });
+  try {
+    await page.locator("#grid-input").evaluate((element) => {
+      const data = new DataTransfer();
+      data.setData(
+        "text/plain",
+        Array.from({ length: 100 }, (_, row) =>
+          Array.from({ length: 10 }, (_, col) =>
+            row === 0 && col === 0 ? "'large range" : "2",
+          ).join("\t"),
+        ).join("\n"),
+      );
+      element.dispatchEvent(
+        new ClipboardEvent("paste", {
+          clipboardData: data,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    assert.match(
+      await page.locator("#paste-summary").textContent(),
+      /A1:J100.*1,000 cells/,
+    );
+    const start = performance.now();
+    await page.locator("#apply-range-paste").click();
+    await page.locator("#paste-dialog").waitFor({ state: "hidden" });
+    await waitForViewerState(
+      page,
+      (state) => !state.busy && state.dirty,
+      "large range committed and rendered",
+    );
+    const elapsedMs = performance.now() - start;
+    const timing = await page.evaluate(() => ({
+      calls: globalThis.__rangeTiming.calls,
+      workerMs: globalThis.__rangeTiming.workerMs,
+    }));
+    assert.equal(
+      timing.calls,
+      1,
+      "a thousand-cell paste is one worker transaction",
+    );
+    const saved = await downloadWorkbook(page, ".xlsx");
+    await assertOpenpyxlReopens(saved.path, {
+      expected: "large range",
+      cacheCell: "P1001",
+      expectedCache: 1098,
+    });
+    await page.locator("#undo-edit").click();
+    await waitForViewerState(
+      page,
+      (state) => !state.busy && !state.dirty,
+      "single large-range undo",
+    );
+    console.log(
+      JSON.stringify({
+        scenario: "large-range-paste",
+        sourceCells: 16001,
+        pastedCells: 1000,
+        ...timing,
+        applyAndRenderMs: elapsedMs,
+      }),
+    );
+  } finally {
+    await page.evaluate(() => {
+      globalThis.__rangeTiming?.restore();
+      delete globalThis.__rangeTiming;
+    });
+  }
+  await page.locator("#file-input").setInputFiles(fileURLToPath(sample));
+  await waitForViewerState(
+    page,
+    (state) =>
+      state.fileName === "operations-report.xlsx" &&
+      !state.busy &&
+      !state.dirty,
+    "original sample restored after scale check",
+  );
+}

--- a/viewer/tests/support/grid-editor.mjs
+++ b/viewer/tests/support/grid-editor.mjs
@@ -1,0 +1,186 @@
+import { createGridEditor } from "../../src/grid-editor.js";
+
+const interaction = {
+  schemaVersion: 1,
+  width: 150,
+  height: 40,
+  cells: [
+    [0, 0, 0, 0, 100, 20],
+    [0, 2, 100, 0, 50, 20],
+    [2, 0, 0, 20, 50, 20],
+    [2, 2, 100, 20, 50, 20],
+  ],
+};
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+function element() {
+  const listeners = new Map();
+  const classes = new Set();
+  const attrs = new Map();
+  let value = "";
+  let disabled = false;
+  return {
+    get value() {
+      return value;
+    },
+    set value(next) {
+      value = String(next).replace(/\r\n?/g, "\n");
+    },
+    hidden: true,
+    get disabled() {
+      return disabled;
+    },
+    set disabled(next) {
+      disabled = Boolean(next);
+      if (disabled && this.ownerDocument?.activeElement === this)
+        this.ownerDocument.activeElement = this.ownerDocument.body;
+    },
+    style: {},
+    dataset: {},
+    parentElement: null,
+    classList: {
+      contains: (name) => classes.has(name),
+      toggle(name, value) {
+        if (value) classes.add(name);
+        else classes.delete(name);
+      },
+    },
+    addEventListener(type, listener) {
+      listeners.set(type, listener);
+    },
+    async fire(type, details = {}) {
+      const event = {
+        target: this,
+        prevented: false,
+        stopped: false,
+        preventDefault() {
+          this.prevented = true;
+        },
+        stopPropagation() {
+          this.stopped = true;
+        },
+        ...details,
+      };
+      await listeners.get(type)?.(event);
+      await flush();
+      return event;
+    },
+    append(child) {
+      child.parentElement = this;
+    },
+    setAttribute(name, value) {
+      attrs.set(name, value);
+    },
+    getAttribute: (name) => attrs.get(name),
+    focus() {
+      if (this.disabled) return;
+      this.focused = true;
+      if (this.ownerDocument) this.ownerDocument.activeElement = this;
+    },
+    setSelectionRange(start, end) {
+      this.selectionStart = start;
+      this.selectionEnd = end;
+    },
+    getBoundingClientRect: () => ({ left: 100, top: 50 }),
+  };
+}
+function setup({
+  createEditor = createGridEditor,
+  readOnly = false,
+  readCell,
+  commitCellEdit,
+  commitRangeEdit,
+  focusOutsideGrid,
+} = {}) {
+  const calls = {
+    reads: [],
+    commits: [],
+    ranges: [],
+    selections: [],
+    errors: [],
+    exits: [],
+  };
+  const exitTargets = { previous: element(), next: element() };
+  const elements = Object.fromEntries(
+    [
+      "document-surface",
+      "grid-layer",
+      "grid-selection",
+      "grid-input",
+      "grid-status",
+    ].map((id) => [id, element()]),
+  );
+  const svg = {
+    getScreenCTM: () => ({
+      a: 2,
+      b: 0,
+      c: 0,
+      d: 2,
+      e: 100,
+      f: 50,
+      inverse: () => ({ a: 0.5, b: 0, c: 0, d: 0.5, e: -50, f: -25 }),
+    }),
+  };
+  const state = {
+    mode: "sheet",
+    busy: false,
+    documentId: "one",
+    sheetIndex: 0,
+    workbook: { sheetCount: 1 },
+    editState: { capability: "read-write" },
+    client: {
+      readCell: async (...args) => {
+        calls.reads.push(args);
+        return readCell
+          ? readCell(...args)
+          : { value: { kind: "number", value: 10 }, formatted: "10" };
+      },
+    },
+  };
+  const grid = createEditor({
+    state,
+    elements,
+    readOnly,
+    editing: {
+      commitCellEdit: async (...args) => {
+        calls.commits.push(args);
+        return commitCellEdit ? commitCellEdit(...args) : true;
+      },
+      commitRangeEdit: async (...args) => {
+        calls.ranges.push(args);
+        return commitRangeEdit ? commitRangeEdit(...args) : true;
+      },
+    },
+    onSelection: (value) => calls.selections.push(value),
+    focusOutsideGrid: (direction) => {
+      calls.exits.push(direction);
+      if (focusOutsideGrid) return focusOutsideGrid(direction);
+      exitTargets[direction].focus();
+      return true;
+    },
+    showError: (error) => calls.errors.push(error),
+  });
+  grid.mount(interaction, svg);
+  return {
+    grid,
+    state,
+    calls,
+    elements,
+    svg,
+    exitTargets,
+    input: elements["grid-input"],
+    outline: elements["grid-selection"],
+    layer: elements["grid-layer"],
+    surface: elements["document-surface"],
+  };
+}
+
+export { setup, element, deferred, flush, interaction };


### PR DESCRIPTION
## Summary

- Add bounded rectangular clipboard preview and atomic paste, with one undo/redo step and post-paste formula-cache recalculation.
- Protect unapplied Cell Options/Properties drafts and isolate stale save/edit responses from replacement workbooks. Prevent replacement during authoritative mutations.
- Index grid selection and range insertion paths, keeping validation, source-part preservation, and resource limits intact.
- Add an explicit read-only publication-handoff rehearsal to the existing release workflow. Both rehearsal and tag publication authenticate the exact artifact and use the same bundle/repack verifier.

No package versions or release tags change. Manual verification cannot publish packages, and the tag-only publishing guard remains unchanged.

## Verification

Local core all-feature tests (1,117, required OpenPyXL), no-default tests (352), renderer tests (474), binding tests (35), viewer tests (127), worker tests (159), Python tests (882), TypeScript consumer checks, API snapshot (149 items), strict Clippy/native/WASM lanes, rustdoc and three semver-checks modes pass.

Chrome 150 source/installed worker gates and the complete viewer journey pass, including draft guards, stale saves, quoted/multiline TSV, atomic rejection, formula-cache save/reopen, desktop/mobile previews, and a 1,000-cell paste in a 16,001-cell workbook. VS Code 1.134.0 and 1.96.0 trusted/untrusted/virtual workspace journeys pass.

All four pinned-nightly ASAN fuzz smokes pass. Clean-source Cargo packaging, exact package checks, and `cargo publish --dry-run --locked` pass; no upload occurred. Workflow policy, source hygiene, formatting, and diff checks pass.

Local Node/npm are 26.7/11.19; hosted checks validate the pinned 24.18/11.16 environment. The new hosted rehearsal will run on the exact canonical main revision after integration, using the existing two-candidate and 52-file evidence gates.
