### PR TITLE
fix: rehearse existing renderer packages without publication

### DIFF
--- a/.github/workflows/render-package-release.yml
+++ b/.github/workflows/render-package-release.yml
@@ -275,6 +275,7 @@ jobs:
           python3 scripts/test_check_render_browser_release_evidence.py
           python3 scripts/test_check_render_package.py
           python3 scripts/test_check_npm_registry_evidence.py
+          python3 scripts/test_npm_dry_run.py
           python3 scripts/test_render_supply_chain.py
           python3 scripts/test_check_render_oracle_release_evidence.py
           python3 scripts/render_supply_chain.py notice \
@@ -333,6 +334,8 @@ jobs:
             --npm-pack "$output/npm-pack.json" \
             --git-rev "$GITHUB_SHA" \
             --write-report "$output/package-report.json"
+          test "$(npm config get force)" = "false"
+          sha256sum "$archive" > "$archive.sha256"
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             ARCHIVE="$archive" python3 - <<'PY'
           import hashlib
@@ -509,13 +512,15 @@ jobs:
                   "browser-proven package differs from release candidate"
               )
           PY
+            npm publish --dry-run --ignore-scripts --access public "$archive" \
+              2>&1 | tee "$output/npm-publish-dry-run.txt"
           else
             test "$GITHUB_EVENT_NAME" = "workflow_dispatch"
-            echo "workflow_dispatch verified the locally rebuilt package without publication prerequisites"
+            echo "workflow_dispatch packaging rehearsal; registry availability not checked"
+            npm publish --dry-run --ignore-scripts --access public --force "$archive" \
+              2>&1 | tee "$output/npm-publish-dry-run.txt"
           fi
-          npm publish --dry-run --ignore-scripts --access public "$archive" \
-            2>&1 | tee "$output/npm-publish-dry-run.txt"
-          sha256sum "$archive" > "$archive.sha256"
+          sha256sum --check --strict "$archive.sha256"
           consumer="$RUNNER_TEMP/render-worker-consumer"
           rm -rf "$consumer"
           mkdir -p "$consumer"
@@ -943,6 +948,7 @@ jobs:
       - name: Publish exact package with provenance
         if: steps.registry.outputs.already_published != 'true'
         run: |
+          test "$(npm config get force)" = "false"
           version="${{ steps.package.outputs.version }}"
           npm publish \
             "target/render-package/rxls-render-worker-$version.tgz" \

--- a/scripts/check_workflow_policy.py
+++ b/scripts/check_workflow_policy.py
@@ -167,7 +167,7 @@ ORACLE_HARDENING_WORKFLOW_SHA256 = (
     "b52b8bde803f6cfc2ffb40f533febf6b5d75dcb17326943546497c921e0c60cc"
 )
 RENDER_PACKAGE_RELEASE_WORKFLOW_SHA256 = (
-    "b125148dde44cb51b9e569c19eccce2b1be9a6dc74e4a9ea52c228d01c4bf6ca"
+    "8e89442f1843fdf417b87424b1c4c79875b78384e62a1d5d6d128ffdbf73f311"
 )
 WASM_PACKAGE_RELEASE_WORKFLOW_SHA256 = (
     "39a36f584d18859cb9ddcdbf0ee45cc2ef5712acb0448bfde575818b7ebfeac8"
@@ -5445,10 +5445,23 @@ def audit_render_package_release_workflow(path: Path, text: str) -> list[str]:
         errors.append(
             f"{path}: pull requests must never enter the registry release workflow"
         )
-    if re.search(r"\bnpm\s+publish\b[^\n]*--force\b", text):
-        errors.append(f"{path}: forced npm publication is forbidden")
-    if len(re.findall(r"^\s*npm publish\b", text, re.MULTILINE)) != 2:
-        errors.append(f"{path}: expected exactly one dry-run and one real npm publish")
+    force_guard = 'test "$(npm config get force)" = "false"'
+    manual_dry_run = (
+        'npm publish --dry-run --ignore-scripts --access public --force "$archive"'
+    )
+    # The manual rehearsal may bypass registry availability, never --dry-run.
+    # All other force settings, including fresh-runner config, remain forbidden.
+    other_force_uses = text.replace(force_guard, "").replace(manual_dry_run, "", 1)
+    if re.search(r"\bforce\b|npm_config_force", other_force_uses, re.IGNORECASE):
+        errors.append(
+            f"{path}: npm force is allowed only on the exact manual dry-run command"
+        )
+    if text.count(force_guard) != 2:
+        errors.append(
+            f"{path}: verification and publication must each reject inherited npm force"
+        )
+    if len(re.findall(r"^\s*npm publish\b", text, re.MULTILINE)) != 3:
+        errors.append(f"{path}: expected exactly two scoped dry-runs and one real npm publish")
     if text.count('npm view "$spec" \\') != 2:
         errors.append(
             f"{path}: registry preflight and postpublication verification must both run"
@@ -5624,6 +5637,27 @@ def audit_render_package_release_workflow(path: Path, text: str) -> list[str]:
         errors.append(
             f"{path}: npm publication must have exactly one exact tag-push job guard"
         )
+    publication_step = _single_yaml_block(
+        path,
+        publish_job,
+        "- name: Publish exact package with provenance",
+        6,
+        "render package protected publication step",
+        errors,
+    )
+    if _normalized_active_commands(publication_step) != [
+        "- name: Publish exact package with provenance",
+        "if: steps.registry.outputs.already_published != 'true'",
+        "run: |",
+        force_guard,
+        'version="${{ steps.package.outputs.version }}"',
+        'npm publish "target/render-package/rxls-render-worker-$version.tgz" '
+        "--ignore-scripts --access public",
+    ]:
+        errors.append(
+            f"{path}: protected publication must reject inherited force first and "
+            "publish only the exact unforced candidate"
+        )
     reverify_step = _single_yaml_block(
         path,
         publish_job,
@@ -5793,6 +5827,7 @@ def audit_render_package_release_workflow(path: Path, text: str) -> list[str]:
         "python3 scripts/test_check_render_browser_release_evidence.py",
         "python3 scripts/test_check_render_package.py",
         "python3 scripts/test_check_npm_registry_evidence.py",
+        "python3 scripts/test_npm_dry_run.py",
         "python3 scripts/test_render_supply_chain.py",
         "python3 scripts/test_check_render_oracle_release_evidence.py",
         "python3 scripts/render_supply_chain.py notice --manifest-path "
@@ -5826,6 +5861,13 @@ def audit_render_package_release_workflow(path: Path, text: str) -> list[str]:
             f"{path}: local pack, dry-run, and consumer verification must be one "
             "unconditional step"
         )
+    if _normalized_active_commands(pack_step)[:4] != [
+        "- name: Pack, inspect, dry-run, and consume",
+        "shell: bash",
+        "run: |",
+        "set -euo pipefail",
+    ]:
+        errors.append(f"{path}: pack and dry-run verification must retain strict shell errors")
     push_guard = 'if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then'
     dispatch_guard = 'test "$GITHUB_EVENT_NAME" = "workflow_dispatch"'
     if pack_step.count(push_guard) != 1 or pack_step.count(dispatch_guard) != 1:
@@ -5839,16 +5881,19 @@ def audit_render_package_release_workflow(path: Path, text: str) -> list[str]:
     )
     tag_branch_close = (
         "          PY\n"
+        '            npm publish --dry-run --ignore-scripts --access public "$archive" \\\n'
+        '              2>&1 | tee "$output/npm-publish-dry-run.txt"\n'
         "          else\n"
         '            test "$GITHUB_EVENT_NAME" = "workflow_dispatch"\n'
-        "            echo \"workflow_dispatch verified the locally rebuilt package "
-        "without publication prerequisites\"\n"
+        '            echo "workflow_dispatch packaging rehearsal; registry availability not checked"\n'
+        f"            {manual_dry_run} \\\n"
+        '              2>&1 | tee "$output/npm-publish-dry-run.txt"\n'
         "          fi\n"
     )
     if pack_step.count(tag_branch_open) != 1 or pack_step.count(tag_branch_close) != 1:
         errors.append(
-            f"{path}: browser receipt must use one exact push branch with a "
-            "fail-closed dispatch alternative"
+            f"{path}: browser receipt and unforced tag dry-run must use one exact "
+            "push branch with a fail-closed manual-only force dry-run alternative"
         )
     tag_start = pack_step.find(tag_branch_open)
     tag_close_start = pack_step.find(tag_branch_close, max(tag_start, 0))
@@ -5880,6 +5925,8 @@ def audit_render_package_release_workflow(path: Path, text: str) -> list[str]:
         'sha256sum "$output/render-worker-sbom.cdx.json"',
         "npm pack --json --pack-destination",
         "python3 scripts/check_render_package.py",
+        force_guard,
+        'sha256sum "$archive" > "$archive.sha256"',
     )
     prefix_positions = [pack_prefix.find(value) for value in prefix_order]
     if (
@@ -5890,10 +5937,21 @@ def audit_render_package_release_workflow(path: Path, text: str) -> list[str]:
         or pack_prefix.count("python3 scripts/check_render_package.py") != 1
         or pack_prefix.count('--npm-pack "$output/npm-pack.json"') != 1
         or pack_prefix.count("npm pack --json --pack-destination") != 1
+        or pack_prefix.count(force_guard) != 1
+        or pack_step.count('sha256sum "$archive" > "$archive.sha256"') != 1
     ):
         errors.append(
-            f"{path}: dispatch must run deterministic SBOM, package, and archive "
-            "validation before the tag-only browser binding"
+            f"{path}: dispatch must run deterministic SBOM, package, archive "
+            "validation, force rejection, and hash capture before event selection"
+        )
+    if not pack_prefix.endswith(
+        '            --write-report "$output/package-report.json"\n'
+        f"          {force_guard}\n"
+        '          sha256sum "$archive" > "$archive.sha256"\n'
+    ):
+        errors.append(
+            f"{path}: package validation must immediately precede the force guard "
+            "and original archive hash capture"
         )
     browser_receipt = 'Path("target/render-package/browser-prerequisite.json")'
     browser_mismatch = "browser-proven package differs from release candidate"
@@ -5909,8 +5967,7 @@ def audit_render_package_release_workflow(path: Path, text: str) -> list[str]:
             "during local package verification"
         )
     suffix_order = (
-        "npm publish --dry-run --ignore-scripts --access public",
-        'sha256sum "$archive" > "$archive.sha256"',
+        'sha256sum --check --strict "$archive.sha256"',
         'consumer="$RUNNER_TEMP/render-worker-consumer"',
         'rm -rf "$consumer"',
         'mkdir -p "$consumer"',
@@ -5924,10 +5981,12 @@ def audit_render_package_release_workflow(path: Path, text: str) -> list[str]:
         any(index < 0 for index in suffix_positions)
         or suffix_positions != sorted(suffix_positions)
         or any(pack_step.count(value) != 1 for value in suffix_order)
+        or _normalized_active_commands(pack_suffix)[: len(suffix_order)]
+        != list(suffix_order)
     ):
         errors.append(
-            f"{path}: dry-run, checksum, and clean installed consumer must run "
-            "after the event-specific browser branch"
+            f"{path}: strict unchanged-archive verification and the clean installed "
+            "consumer must run immediately after the scoped dry-run branch"
         )
     build_step = _single_yaml_block(
         path,

--- a/scripts/test_npm_dry_run.py
+++ b/scripts/test_npm_dry_run.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Exercise npm dry-run guards against a loopback-only existing-version registry.
+
+Direct invocation requires POSIX, Node 24.18.0/npm 11.16.0 and fails if unavailable.
+Ordinary unittest discovery skips only when this pinned runtime (including bash
+and sha256sum) is unavailable; RXLS_REQUIRE_PINNED_NPM=1 makes discovery strict.
+No credentials, real registry, package scripts, or dependencies are used.
+"""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import hashlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import io
+import json
+import os
+from pathlib import Path
+import re
+import selectors
+import shutil
+import signal
+import subprocess
+import sys
+import tarfile
+import tempfile
+import textwrap
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/render-package-release.yml"
+PACKAGE = "rxls-npm-dry-run-fixture"
+VERSION = "0.0.0"
+MAX_OUTPUT_BYTES = 64 * 1024
+COMMAND_TIMEOUT_SECONDS = 20
+STRICT_ENV = "RXLS_REQUIRE_PINNED_NPM"
+
+
+def isolated_environment(root: Path) -> dict[str, str]:
+    home = root / "home"
+    home.mkdir()
+    user_config, global_config = root / "user.npmrc", root / "global.npmrc"
+    user_config.write_text("", encoding="utf-8")
+    global_config.write_text("", encoding="utf-8")
+    return {
+        "PATH": os.environ.get("PATH", os.defpath),
+        "HOME": str(home),
+        "TMPDIR": str(root),
+        "LANG": "C",
+        "CI": "1",
+        "NO_COLOR": "1",
+        "NPM_CONFIG_USERCONFIG": str(user_config),
+        "NPM_CONFIG_GLOBALCONFIG": str(global_config),
+        "NPM_CONFIG_CACHE": str(root / "npm-cache"),
+        "NPM_CONFIG_REGISTRY": "http://127.0.0.1:1/",
+        "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+        "NPM_CONFIG_AUDIT": "false",
+        "NPM_CONFIG_FUND": "false",
+        "NPM_CONFIG_FETCH_RETRIES": "0",
+        "NPM_CONFIG_FETCH_TIMEOUT": "3000",
+    }
+
+
+def command(argv: list[str], root: Path, env: dict[str, str]) -> tuple[int, str]:
+    """Bound captured bytes before growth, and terminate the whole command group."""
+    process = subprocess.Popen(
+        argv, cwd=root, env=env, stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT, start_new_session=True,
+    )
+    assert process.stdout is not None
+    output = bytearray()
+    deadline = time.monotonic() + COMMAND_TIMEOUT_SECONDS
+    completed = False
+    try:
+        with selectors.DefaultSelector() as selector:
+            selector.register(process.stdout, selectors.EVENT_READ)
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise AssertionError("npm regression subprocess exceeded 20 seconds")
+                if not selector.select(min(remaining, 0.25)):
+                    continue
+                chunk = os.read(process.stdout.fileno(), min(4096, MAX_OUTPUT_BYTES - len(output) + 1))
+                if not chunk:
+                    break
+                if len(output) + len(chunk) > MAX_OUTPUT_BYTES:
+                    raise AssertionError("npm regression subprocess exceeded 64 KiB output")
+                output.extend(chunk)
+        status = process.wait(timeout=max(0.01, deadline - time.monotonic()))
+        completed = True
+        return status, output.decode("utf-8", errors="replace")
+    finally:
+        if not completed or process.poll() is None:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        process.wait(timeout=5)
+        process.stdout.close()
+
+
+def workflow_fragment() -> str:
+    """Use actual publish/event/checksum statements, excluding only browser proof."""
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    step = workflow.split("      - name: Pack, inspect, dry-run, and consume\n", 1)[1]
+    body = textwrap.dedent(step.split("        run: |\n", 1)[1].split("      - name:", 1)[0])
+    fragment = body.split('  --write-report "$output/package-report.json"\n', 1)[1]
+    fragment = fragment.split('consumer="$RUNNER_TEMP/render-worker-consumer"\n', 1)[0]
+    fragment, removed = re.subn(
+        r"(?ms)^  ARCHIVE=\"\$archive\" python3 - <<'PY'\n.*?^PY\n",
+        "  : # Browser prerequisite proof is independently covered.\n",
+        fragment,
+    )
+    if removed != 1 or "${{" in fragment:
+        raise AssertionError("unexpected workflow dry-run fragment boundary")
+    return 'set -euo pipefail\narchive="$PWD/fixture.tgz"\noutput="$PWD/output"\n' + fragment
+
+
+class NpmDryRunTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            if os.name != "posix":
+                raise RuntimeError("POSIX process groups and pipe selectors are required")
+            for executable in ("node", "npm", "bash", "sha256sum"):
+                if shutil.which(executable) is None:
+                    raise RuntimeError(f"missing {executable}")
+            with tempfile.TemporaryDirectory(prefix="rxls-npm-runtime-") as temporary:
+                root = Path(temporary)
+                env = isolated_environment(root)
+                for executable, expected in (("node", "v24.18.0"), ("npm", "11.16.0")):
+                    status, output = command([executable, "--version"], root, env)
+                    if status != 0 or output.strip() != expected:
+                        raise RuntimeError(f"expected {executable} {expected}, got {output.strip()[:160]!r}")
+        except (OSError, RuntimeError, AssertionError, subprocess.SubprocessError) as error:
+            message = f"Pinned npm dry-run runtime unavailable: {error}"
+            if os.environ.get(STRICT_ENV) == "1":
+                raise RuntimeError(message) from error
+            raise unittest.SkipTest(message + f"; set {STRICT_ENV}=1 to require it") from error
+
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory(prefix="rxls-npm-dry-run-")
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.env = isolated_environment(self.root)
+        (self.root / "output").mkdir()
+        metadata = {"name": PACKAGE, "version": VERSION, "license": "MIT"}
+        package_json = json.dumps(metadata).encode("utf-8")
+        archive = io.BytesIO()
+        with tarfile.open(fileobj=archive, mode="w") as tar:
+            member = tarfile.TarInfo("package/package.json")
+            member.size, member.mode, member.mtime = len(package_json), 0o644, 0
+            tar.addfile(member, io.BytesIO(package_json))
+        self.original = gzip.compress(archive.getvalue(), mtime=0)
+        self.archive = self.root / "fixture.tgz"
+        self.archive.write_bytes(self.original)
+        self.requests: list[tuple[str, str, bool]] = []
+        requests = self.requests
+        integrity = "sha512-" + base64.b64encode(hashlib.sha512(self.original).digest()).decode("ascii")
+
+        class Registry(BaseHTTPRequestHandler):
+            def log_message(self, *_args: object) -> None:
+                pass
+
+            def respond(self) -> None:
+                requests.append((self.command, self.path, "Authorization" in self.headers))
+                status = 200 if self.command in {"GET", "HEAD"} and self.path == "/" + PACKAGE else 405
+                if len(requests) > 32:
+                    status = 429
+                payload = json.dumps({
+                    "name": PACKAGE, "dist-tags": {"latest": VERSION},
+                    "versions": {VERSION: {**metadata, "dist": {
+                        "integrity": integrity,
+                        "tarball": f"http://127.0.0.1:{self.server.server_port}/fixture.tgz",
+                    }}},
+                }).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.send_header("Connection", "close")
+                self.end_headers()
+                if self.command != "HEAD":
+                    self.wfile.write(payload)
+
+            do_GET = do_HEAD = do_PUT = do_POST = do_DELETE = do_PATCH = do_OPTIONS = respond
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Registry)
+        server.daemon_threads = True
+        thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.05}, daemon=True)
+        thread.start()
+        self.addCleanup(thread.join, 2)
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        self.env["NPM_CONFIG_REGISTRY"] = f"http://127.0.0.1:{server.server_port}/"
+        self.addCleanup(self.assert_safety)
+
+    def assert_safety(self) -> None:
+        self.assertEqual(self.archive.read_bytes(), self.original, "dry run changed the TGZ")
+        self.assertTrue(all(method in {"GET", "HEAD"} for method, _, _ in self.requests), self.requests)
+        self.assertTrue(all(not auth for _, _, auth in self.requests), "registry received credentials")
+        self.assertLessEqual(len(self.requests), 32)
+
+    def run_workflow(self, event: str) -> tuple[int, str]:
+        return command(["bash", "--noprofile", "--norc", "-c", workflow_fragment()], self.root, {**self.env, "GITHUB_EVENT_NAME": event})
+
+    def assert_existing_version_rejected(self, result: tuple[int, str]) -> None:
+        status, output = result
+        self.assertNotEqual(status, 0, output[-4000:])
+        self.assertRegex(output, r"(?i)(previously published|already exists|cannot publish over|EPUBLISHCONFLICT)")
+        self.assertTrue(self.requests, "npm did not query the existing-version registry")
+
+    def test_manual_rehearsal_accepts_unchanged_existing_version_without_writes(self) -> None:
+        self.assert_existing_version_rejected(command(
+            ["npm", "publish", "--dry-run", "--ignore-scripts", "--access", "public", str(self.archive)],
+            self.root, self.env,
+        ))
+        status, output = self.run_workflow("workflow_dispatch")
+        self.assertEqual(status, 0, output[-4000:])
+        self.assertIn("workflow_dispatch packaging rehearsal; registry availability not checked", output)
+        self.assertIn("fixture.tgz: OK", output)
+        self.assertTrue((self.root / "output/npm-publish-dry-run.txt").is_file())
+
+    def test_tag_dry_run_still_rejects_existing_version(self) -> None:
+        self.assert_existing_version_rejected(self.run_workflow("push"))
+
+    def test_unsupported_event_stops_before_registry_access(self) -> None:
+        status, output = self.run_workflow("pull_request")
+        self.assertNotEqual(status, 0, output[-4000:])
+        self.assertEqual(self.requests, [])
+
+    def test_inherited_force_stops_before_registry_access(self) -> None:
+        config = Path(self.env["NPM_CONFIG_GLOBALCONFIG"])
+        for source in ("global_config", "environment"):
+            with self.subTest(source=source):
+                config.write_text("force=true\n" if source == "global_config" else "", encoding="utf-8")
+                if source == "environment":
+                    self.env["NPM_CONFIG_FORCE"] = "true"
+                status, output = self.run_workflow("workflow_dispatch")
+                self.assertNotEqual(status, 0, output[-4000:])
+                self.assertEqual(self.requests, [])
+
+    def test_protected_publish_prefix_rejects_inherited_force(self) -> None:
+        step = WORKFLOW.read_text(encoding="utf-8").split(
+            "      - name: Publish exact package with provenance\n", 1,
+        )[1]
+        body = textwrap.dedent(step.split("        run: |\n", 1)[1].split("      - name:", 1)[0])
+        # Never execute the version expansion or actual publish, even if the
+        # guard is removed: only this prefix can reach the subprocess.
+        prefix, separator, _ = body.partition('version="${{ steps.package.outputs.version }}"')
+        self.assertTrue(separator, "protected publish prefix boundary changed")
+        self.assertNotIn("publish", prefix)
+        self.assertNotIn("${{", prefix)
+        Path(self.env["NPM_CONFIG_GLOBALCONFIG"]).write_text("force=true\n", encoding="utf-8")
+        status, output = command(
+            ["bash", "--noprofile", "--norc", "-c", "set -euo pipefail\n" + prefix],
+            self.root, self.env,
+        )
+        self.assertNotEqual(status, 0, output[-4000:])
+        self.assertEqual(self.requests, [])
+
+
+@unittest.skipUnless(os.name == "posix", "bounded command fixture requires POSIX process groups")
+class NpmHarnessBoundTests(unittest.TestCase):
+    def test_subprocess_output_overflow_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="rxls-npm-bound-") as temporary:
+            root = Path(temporary)
+            with self.assertRaisesRegex(AssertionError, "64 KiB output"):
+                command([sys.executable, "-c", "print('x' * 65537)"], root, isolated_environment(root))
+
+    def test_subprocess_deadline_is_enforced(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="rxls-npm-bound-") as temporary:
+            root = Path(temporary)
+            with patch.dict(command.__globals__, COMMAND_TIMEOUT_SECONDS=0.05):
+                with self.assertRaisesRegex(AssertionError, "exceeded"):
+                    command([sys.executable, "-c", "import time; time.sleep(5)"], root, isolated_environment(root))
+
+    def test_deadline_kills_descendant_after_process_leader_exits(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="rxls-npm-bound-") as temporary:
+            root = Path(temporary)
+            marker = root / "descendant-survived"
+            script = (
+                "import os,pathlib,sys,time\n"
+                "if os.fork(): sys.exit(0)\n"
+                "time.sleep(0.3)\n"
+                "pathlib.Path(sys.argv[1]).write_text('survived')\n"
+            )
+            with patch.dict(command.__globals__, COMMAND_TIMEOUT_SECONDS=0.1):
+                with self.assertRaisesRegex(AssertionError, "exceeded"):
+                    command([sys.executable, "-c", script, str(marker)], root, isolated_environment(root))
+            time.sleep(0.4)
+            self.assertFalse(marker.exists(), "timed-out descendant outlived its exited process leader")
+
+
+if __name__ == "__main__":
+    os.environ[STRICT_ENV] = "1"
+    unittest.main()

--- a/scripts/test_workflow_policy.py
+++ b/scripts/test_workflow_policy.py
@@ -3074,6 +3074,155 @@ steps:
             [],
         )
 
+    def test_render_package_manual_rehearsal_contract(self) -> None:
+        original = RENDER_PACKAGE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertEqual(original.count('test "$(npm config get force)" = "false"'), 2)
+        self.assertEqual(original.count("--access public --force"), 1)
+        self.assertIn('sha256sum --check --strict "$archive.sha256"', original)
+        self.assertIn("python3 scripts/test_npm_dry_run.py", original)
+        with mock.patch.object(
+            self.policy,
+            "RENDER_PACKAGE_RELEASE_WORKFLOW_SHA256",
+            hashlib.sha256(original.encode("utf-8")).hexdigest(),
+        ):
+            self.assertEqual(
+                self.policy.audit_render_package_release_workflow(
+                    Path("render-package-release.yml"), original
+                ),
+                [],
+            )
+
+    def test_render_package_rehearsal_rejects_scope_and_archive_mutations(self) -> None:
+        original = RENDER_PACKAGE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        force_guard = '          test "$(npm config get force)" = "false"\n'
+        before_hash = '          sha256sum "$archive" > "$archive.sha256"\n'
+        after_hash = '          sha256sum --check --strict "$archive.sha256"\n'
+        manual_publish = (
+            '            npm publish --dry-run --ignore-scripts --access public --force "$archive" \\\n'
+            '              2>&1 | tee "$output/npm-publish-dry-run.txt"\n'
+        )
+        tag_publish = manual_publish.replace(" --force", "")
+        dispatch_guard = '            test "$GITHUB_EVENT_NAME" = "workflow_dispatch"\n'
+        publish_prefix = (
+            "      - name: Publish exact package with provenance\n"
+            "        if: steps.registry.outputs.already_published != 'true'\n"
+            "        run: |\n"
+        )
+        mutations = {
+            "manual_missing_dry_run": original.replace(
+                manual_publish, manual_publish.replace(" --dry-run", ""), 1
+            ),
+            "manual_missing_ignore_scripts": original.replace(
+                manual_publish, manual_publish.replace(" --ignore-scripts", ""), 1
+            ),
+            "tag_dry_run_forced": original.replace(tag_publish, manual_publish, 1),
+            "manual_dry_run_unforced": original.replace(manual_publish, tag_publish, 1),
+            "manual_dry_run_outside_guard": original.replace(manual_publish, "", 1).replace(
+                after_hash, after_hash + manual_publish, 1
+            ),
+            "manual_force_duplicated": original.replace(
+                manual_publish, manual_publish + manual_publish, 1
+            ),
+            "manual_event_guard_relaxed": original.replace(
+                dispatch_guard, '            test "$GITHUB_EVENT_NAME" != "push"\n', 1
+            ),
+            "manual_event_guard_after_publish": original.replace(dispatch_guard, "", 1).replace(
+                manual_publish, manual_publish + dispatch_guard, 1
+            ),
+            "manual_failure_swallowed": original.replace(
+                manual_publish, manual_publish.rstrip("\n") + " || true\n", 1
+            ),
+            "dry_run_record_not_retained": original.replace(
+                manual_publish, manual_publish.replace('"$output/npm-publish-dry-run.txt"', "/dev/null"), 1
+            ),
+            "force_environment_uppercase": original.replace(
+                force_guard, force_guard + "          export NPM_CONFIG_FORCE=true\n", 1
+            ),
+            "force_environment_lowercase": original.replace(
+                force_guard, force_guard + "          export npm_config_force=true\n", 1
+            ),
+            "force_global_config": original.replace(
+                force_guard, force_guard + "          npm config set force true\n", 1
+            ),
+            "force_npmrc_override": original.replace(
+                force_guard, force_guard + '          echo "force=true" >> "$HOME/.npmrc"\n', 1
+            ),
+            "verify_force_guard_removed": original.replace(force_guard, "", 1),
+            "verify_force_guard_inverted": original.replace(
+                force_guard, force_guard.replace('= "false"', '= "true"'), 1
+            ),
+            "verify_force_guard_late": original.replace(force_guard, "", 1).replace(
+                after_hash, after_hash + force_guard, 1
+            ),
+            "verify_force_guard_swallowed": original.replace(
+                force_guard, force_guard.rstrip("\n") + " || true\n", 1
+            ),
+            "publish_force_guard_removed": original.replace(
+                publish_prefix + force_guard, publish_prefix, 1
+            ),
+            "publish_force_guard_late": original.replace(
+                publish_prefix + force_guard, publish_prefix, 1
+            ).replace(
+                '            --ignore-scripts --access public\n',
+                '            --ignore-scripts --access public\n' + force_guard,
+                1,
+            ),
+            "publish_force_guard_swallowed": original.replace(
+                publish_prefix + force_guard,
+                publish_prefix + force_guard.rstrip("\n") + " || true\n",
+                1,
+            ),
+            "actual_publication_forced": original.replace(
+                '            --ignore-scripts --access public\n',
+                '            --ignore-scripts --access public --force\n',
+                1,
+            ),
+            "archive_hash_missing_before": original.replace(before_hash, "", 1),
+            "archive_hash_captured_after": original.replace(before_hash, "", 1).replace(
+                after_hash, before_hash + after_hash, 1
+            ),
+            "archive_hash_replaced_after": original.replace(
+                after_hash, before_hash + after_hash, 1
+            ),
+            "archive_hash_missing_after": original.replace(after_hash, "", 1),
+            "archive_hash_not_strict": original.replace(
+                after_hash, after_hash.replace(" --strict", ""), 1
+            ),
+            "archive_hash_failure_swallowed": original.replace(
+                after_hash, after_hash.rstrip("\n") + " || true\n", 1
+            ),
+            "archive_modified_after_check": original.replace(
+                after_hash, after_hash + '          touch "$archive"\n', 1
+            ),
+            "consumer_moved_before_hash": original.replace(after_hash, "", 1).replace(
+                '          npm install --ignore-scripts "$GITHUB_WORKSPACE/$archive"\n',
+                '          npm install --ignore-scripts "$GITHUB_WORKSPACE/$archive"\n' + after_hash,
+                1,
+            ),
+            "dry_run_test_removed": original.replace(
+                "          python3 scripts/test_npm_dry_run.py\n", "", 1
+            ),
+            "pack_errexit_removed": original.replace(
+                "      - name: Pack, inspect, dry-run, and consume\n"
+                "        shell: bash\n        run: |\n          set -euo pipefail\n",
+                "      - name: Pack, inspect, dry-run, and consume\n"
+                "        shell: bash\n        run: |\n          set -eu\n",
+                1,
+            ),
+        }
+        for name, workflow in mutations.items():
+            with self.subTest(name=name):
+                self.assertNotEqual(workflow, original)
+                with mock.patch.object(
+                    self.policy,
+                    "RENDER_PACKAGE_RELEASE_WORKFLOW_SHA256",
+                    hashlib.sha256(workflow.encode("utf-8")).hexdigest(),
+                ):
+                    errors = self.policy.audit_render_package_release_workflow(
+                        Path("render-package-release.yml"), workflow
+                    )
+                self.assertTrue(errors)
+
     def test_render_package_release_rejects_unsafe_publication_paths(self) -> None:
         original = RENDER_PACKAGE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
         mutations = {
@@ -3331,10 +3480,10 @@ steps:
             ),
             "manual_suffix_independent_event_guard": original.replace(
                 "          fi\n"
-                "          npm publish --dry-run --ignore-scripts --access public \"$archive\" \\\n",
+                '          sha256sum --check --strict "$archive.sha256"\n',
                 "          fi\n"
                 '          if [[ "${{ github.event_name }}" == "push" ]]; then\n'
-                "            npm publish --dry-run --ignore-scripts --access public \"$archive\" \\\n",
+                '            sha256sum --check --strict "$archive.sha256"\n',
                 1,
             ).replace(
                 "          NODE\n"
@@ -3346,8 +3495,8 @@ steps:
             ),
             "manual_downstream_inside_event_guard": original.replace(
                 "          fi\n"
-                "          npm publish --dry-run --ignore-scripts --access public \"$archive\" \\\n",
-                "          npm publish --dry-run --ignore-scripts --access public \"$archive\" \\\n",
+                '          sha256sum --check --strict "$archive.sha256"\n',
+                '          sha256sum --check --strict "$archive.sha256"\n',
                 1,
             ).replace(
                 "          NODE\n"
@@ -3378,14 +3527,23 @@ steps:
                 1,
             ).replace(
                 "          PY\n"
+                '            npm publish --dry-run --ignore-scripts --access public "$archive" \\\n'
+                '              2>&1 | tee "$output/npm-publish-dry-run.txt"\n'
                 "          else\n"
                 '            test "$GITHUB_EVENT_NAME" = "workflow_dispatch"\n'
-                "            echo \"workflow_dispatch verified the locally rebuilt package without publication prerequisites\"\n"
+                '            echo "workflow_dispatch packaging rehearsal; registry availability not checked"\n'
+                '            npm publish --dry-run --ignore-scripts --access public --force "$archive" \\\n'
+                '              2>&1 | tee "$output/npm-publish-dry-run.txt"\n'
                 "          fi\n",
                 "          PY\n"
                 '          if [[ "$GITHUB_EVENT_NAME" != "push" ]]; then\n'
                 '            test "$GITHUB_EVENT_NAME" = "workflow_dispatch"\n'
-                "            echo \"workflow_dispatch verified the locally rebuilt package without publication prerequisites\"\n"
+                '            echo "workflow_dispatch packaging rehearsal; registry availability not checked"\n'
+                '            npm publish --dry-run --ignore-scripts --access public --force "$archive" \\\n'
+                '              2>&1 | tee "$output/npm-publish-dry-run.txt"\n'
+                "          else\n"
+                '            npm publish --dry-run --ignore-scripts --access public "$archive" \\\n'
+                '              2>&1 | tee "$output/npm-publish-dry-run.txt"\n'
                 "          fi\n",
                 1,
             ),


### PR DESCRIPTION
## Summary

Manual renderer package verification currently fails when its unchanged version
already exists on npm: npm 11.16.0 checks registry versions even with `--dry-run`.
This keeps packaging rehearsal independent of registry availability without
changing package versions or enabling publication.

- Permit `--force` only on the explicitly guarded manual `--dry-run` command.
- Keep tag verification and actual publication unforced, and reject inherited
  npm force configuration in both verification and publication runners.
- Bind the archive checksum before rehearsal and verify it before installed
  consumption; preserve registry integrity/provenance checks.
- Exercise the real workflow fragment against an isolated loopback registry
  with pinned Node/npm, unchanged archive bytes and zero write requests.

## Validation

- RED reproduced the existing-version failure and inherited-force acceptance.
- 8 pinned Node 24.18.0 / npm 11.16.0 regression tests passed.
- 57 workflow-policy tests passed, including 32 new semantic mutation cases.
- Full Python discovery passed: 892 tests, pinned npm required, no skips.
- Central workflow policy, public hygiene and `git diff --check` passed.

No product code, package version, renderer baseline or general-WASM workflow
changes. Manual rehearsal explicitly does not establish registry availability.
The actual publication path remains protected and no package was published.
