### PR TITLE
chore(render): prepare worker 0.3.0 release

### DIFF
--- a/bindings/render-wasm/Cargo.lock
+++ b/bindings/render-wasm/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "rxls-render-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "js-sys",
  "rxls",

--- a/bindings/render-wasm/Cargo.toml
+++ b/bindings/render-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rxls-render-wasm"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/bindings/render-wasm/README.md
+++ b/bindings/render-wasm/README.md
@@ -46,9 +46,9 @@ OOXML packages that cannot retain metadata report a stable read-only reason.
 Undo/redo history is bounded to 20 entries and 32 MiB, and every candidate is
 serialized and reopened before it replaces the live session.
 
-The current source build additionally exposes `renderSheetInteractive()`,
-`setCellAndRecalculate()`, and `setRangeAndRecalculate()`; these additions are not
-in the published 0.2.0 package. Interactive rendering returns bounded, text-free
+Version 0.3.0 adds `renderSheetInteractive()`, `setCellAndRecalculate()`, and
+`setRangeAndRecalculate()` to the existing version 2 protocol. These methods are
+not available in 0.2.0. Interactive rendering returns bounded, text-free
 cell rectangles from the same layout pass as the SVG. Recalculating edits apply
 a cell or rectangular range and refresh supported formula
 caches as one atomic, undoable change. Its `recalculation` summary reports

--- a/bindings/render-wasm/THIRD_PARTY_NOTICES.txt
+++ b/bindings/render-wasm/THIRD_PARTY_NOTICES.txt
@@ -5,7 +5,7 @@ Scope:
 - Manifest: bindings/render-wasm/Cargo.toml
 - Target: wasm32-unknown-unknown
 - Dependency edges: Cargo normal edges for the production target
-- Cargo lock SHA-256: cefe2ea10199d1491ba64568b7a9296f545aaf5d2540e2a441e8d7e56df7c32d
+- Cargo lock SHA-256: 4ec9aa075a35b53c0d1d1ea3142c07246d5217e58babf2600b686e0d24ba3894
 - Third-party packages: 84
 - Unique legal texts: 77
 

--- a/bindings/render-wasm/package.json
+++ b/bindings/render-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rxls/render-worker",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "CSP-safe worker facade for bounded rxls spreadsheet rendering",
   "author": {


### PR DESCRIPTION
## Summary

Prepare @rxls/render-worker 0.3.0 by aligning the npm manifest, Rust binding manifest and lockfile. Regenerate the license notice lockfile hash and document that interactive rendering, recalculating edits and rectangular range edits are available in 0.3.0 under the existing v2 protocol.

No runtime, dependency, workflow, core-version or VS Code changes are included.

## Validation

Independent review found no actionable issues. Rust 1.85 formatting, 35 locked native tests, all-target Clippy and documentation with warnings denied passed. Worker JavaScript passed 159 tests; repository Python passed 892 tests after regenerating the notice. Package identity, public hygiene and the 16-file archive contract passed. Pinned Chrome 150.0.7871.115 passed both rebuilt-source and installed-tarball journeys. The unforced npm publication dry run passed; no package has been published.

Publication will use the existing protected render-v0.3.0 workflow only after the merged commit passes its exact-SHA hosted prerequisites.